### PR TITLE
feature: Add support for updating existing GitHub releases with only …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = "com.monta.gradle.changelog"
-version = "1.2.0"
+version = "1.3.0"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
@@ -42,6 +42,11 @@ class GenerateChangeLogCommand : CliktCommand() {
         envvar = "CHANGELOG_GITHUB_RELEASE"
     ).flag("--github-release", "-R", default = false)
 
+    private val update: Boolean by option(
+        help = "Must be set if the github release already exists and should be update with change log instead of created",
+        envvar = "CHANGELOG_GITHUB_UPDATE"
+    ).flag("--github-update", default = false)
+
     private val githubToken: String? by option(
         help = "Github Token used for creating releases",
         envvar = "CHANGELOG_GITHUB_TOKEN"
@@ -73,6 +78,7 @@ class GenerateChangeLogCommand : CliktCommand() {
                 serviceName = serviceName,
                 jiraAppName = jiraAppName,
                 githubRelease = githubRelease,
+                update = update,
                 githubToken = githubToken
             )
 

--- a/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
@@ -14,6 +14,7 @@ class ChangeLogService(
     private val serviceName: String,
     private val jiraAppName: String?,
     private val githubRelease: Boolean,
+    private val update: Boolean,
     githubToken: String?,
 ) {
 
@@ -74,7 +75,11 @@ class ChangeLogService(
         )
 
         if (githubRelease) {
-            changeLog.githubReleaseUrl = gitHubService.createRelease(linkResolvers, changeLog)
+            changeLog.githubReleaseUrl = if (update) {
+                gitHubService.updateRelease(linkResolvers, changeLog)
+            } else {
+                gitHubService.createRelease(linkResolvers, changeLog)
+            }
         }
 
         changeLogPrinter.print(linkResolvers, changeLog)


### PR DESCRIPTION
…the change log.

This is needed for the tool-ocpp-emulator where we create a release by uploading binary installers and we need to only update the release notes in the `changelog-cli` command - see failing build [Bump version to 1.1.2](https://github.com/monta-app/tool-ocpp-emulator/actions/runs/3886331389)