### PR TITLE
fix: supporting mono repos

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("multiplatform") version "1.8.21"
     kotlin("plugin.serialization") version "1.8.21"
     id("io.kotest.multiplatform") version "5.6.2"
-    id("org.jlleitschuh.gradle.ktlint") version "11.3.1"
+    id("org.jlleitschuh.gradle.ktlint") version "11.3.2"
 }
 
 group = "com.monta.gradle.changelog"
@@ -44,11 +44,11 @@ kotlin {
                 // Date Time Support
                 implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.4.0")
                 // Serialization
-                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
+                implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
                 // Atomic
                 implementation("org.jetbrains.kotlinx:atomicfu:0.20.2")
                 // Http Client
-                val ktorVersion = "2.2.4"
+                val ktorVersion = "2.3.0"
                 implementation("io.ktor:ktor-client-core:$ktorVersion")
                 implementation("io.ktor:ktor-client-curl:$ktorVersion")
                 implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
@@ -57,7 +57,7 @@ kotlin {
         }
         val commonTest by getting {
             dependencies {
-                val kotestVersion = "5.6.1"
+                val kotestVersion = "5.6.2"
                 implementation(kotlin("test-common"))
                 implementation(kotlin("test-annotations-common"))
                 implementation("io.kotest:kotest-framework-engine:$kotestVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.monta.gradle.changelog"
-version = "1.6.0"
+version = "1.6.1"
 
 repositories {
     // Use Maven Central for resolving dependencies.

--- a/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
@@ -153,7 +153,12 @@ class GenerateChangeLogCommand : CliktCommand() {
                 slackToken,
                 buildSet {
                     slackChannel?.let { add(it) }
-                    slackChannels?.let { addAll(it) }
+                    slackChannels?.let { list ->
+                        val trimmed = list.filter {
+                            it.isNotEmpty()
+                        }
+                        addAll(trimmed)
+                    }
                 }
             )
         }

--- a/src/commonMain/kotlin/com.monta.changelog/git/GitService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/git/GitService.kt
@@ -1,5 +1,6 @@
 package com.monta.changelog.git
 
+import com.monta.changelog.git.sorter.Tag
 import com.monta.changelog.git.sorter.TagSorter
 import com.monta.changelog.model.Commit
 import com.monta.changelog.util.DebugLogger
@@ -35,11 +36,15 @@ class GitService(
             tags = gitCommandUtil.getTags()
                 .mapNotNull { tag ->
                     when (tagPattern) {
-                        null -> tag
+                        null -> Tag(tag)
                         else -> {
                             // there is a tag pattern, extract group 1
                             val match = tagPattern.matchEntire(tag)
-                            if (match != null) match.groups[1]?.value else null
+                            if (match != null) {
+                                match.groups[1]?.value?.let { Tag(it, tag) }
+                            } else {
+                                null
+                            }
                         }
                     }
                 }
@@ -57,7 +62,7 @@ class GitService(
             }
 
             1 -> {
-                val latestTag = tags[0]
+                val latestTag = tags[0].fullTag
                 DebugLogger.info("only one tag found $latestTag; returning from latest commit to last tag")
                 return CommitInfo(
                     tagName = latestTag.getTagValue(),
@@ -66,8 +71,8 @@ class GitService(
             }
 
             else -> {
-                val latestTag = tags[0]
-                val previousTag = tags[1]
+                val latestTag = tags[0].fullTag
+                val previousTag = tags[1].fullTag
                 DebugLogger.info("returning commits between tag $latestTag and $previousTag")
                 return CommitInfo(
                     tagName = latestTag.getTagValue(),

--- a/src/commonMain/kotlin/com.monta.changelog/git/sorter/DateVerSorter.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/git/sorter/DateVerSorter.kt
@@ -5,10 +5,11 @@ import kotlinx.datetime.LocalDateTime
 
 class DateVerSorter : TagSorter {
 
-    override fun sort(tags: List<String>): List<String> {
+    override fun sort(tags: List<Tag>): List<Tag> {
         return tags.mapNotNull { tag ->
+            val shortTag = tag.shortTag
             // Try to convert to a date
-            val localDateTime = tag.getTagValue().toDate()
+            val localDateTime = shortTag.getTagValue().toDate()
             // Skip if we don't have a valid date
             if (localDateTime == null) {
                 null

--- a/src/commonMain/kotlin/com.monta.changelog/git/sorter/SemVerSorter.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/git/sorter/SemVerSorter.kt
@@ -4,14 +4,15 @@ import com.monta.changelog.git.getTagValue
 
 class SemVerSorter : TagSorter {
 
-    override fun sort(tags: List<String>): List<String> {
+    override fun sort(tags: List<Tag>): List<Tag> {
         return tags.mapNotNull { tag ->
+            val shortTag = tag.shortTag
             // Get the last part of the tag so stuff like releases/tag/2023-02-28-14-39 can still be valid
-            var tagValue = tag.getTagValue()
+            var tagValue = shortTag.getTagValue()
             // Remove the V portion if it's there (Not required for sorting)
             tagValue = tagValue.replace("v", "")
             // We check it's a valid tag by seeing it contains three dots (there is 100% a better way to do this)
-            if (tag.count { it == '.' } >= 2) {
+            if (shortTag.count { it == '.' } >= 2) {
                 tagValue to tag
             } else {
                 null

--- a/src/commonMain/kotlin/com.monta.changelog/git/sorter/TagSorter.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/git/sorter/TagSorter.kt
@@ -1,5 +1,13 @@
 package com.monta.changelog.git.sorter
 
 interface TagSorter {
-    fun sort(tags: List<String>): List<String>
+    fun sort(tags: List<Tag>): List<Tag>
 }
+
+data class Tag(
+    /**
+     * Short tag is what will be sorted by - this might be just the date or version part of a tag
+     */
+    val shortTag: String,
+    val fullTag: String = shortTag,
+)


### PR DESCRIPTION
For the case where we use a regex to match the semver/date version for sorting I threw away the full tag, leading it to fail when fetching the tag information. This fixes that.