### PR TITLE
fix: Fix the unstable semver sorting which lead to wrong release note…

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.monta.gradle.changelog"
-version = "1.7.0"
+version = "1.8.0"
 
 repositories {
     // Use Maven Central for resolving dependencies.
@@ -53,6 +53,8 @@ kotlin {
                 implementation("io.ktor:ktor-client-curl:$ktorVersion")
                 implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
                 implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
+                // Semver parser
+                implementation("io.github.z4kn4fein:semver:2.0.0")
             }
         }
         val commonTest by getting {

--- a/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
@@ -19,11 +19,11 @@ import kotlinx.coroutines.runBlocking
 
 class GenerateChangeLogCommand : CliktCommand() {
     private val banner = """
- __    __   ______   __   __   ______  ______    
-/\ "-./  \ /\  __ \ /\ "-.\ \ /\__  _\/\  __ \   
-\ \ \-./\ \\ \ \/\ \\ \ \-.  \\/_/\ \/\ \  __ \  
- \ \_\ \ \_\\ \_____\\ \_\\"\_\  \ \_\ \ \_\ \_\ 
-  \/_/  \/_/ \/_____/ \/_/ \/_/   \/_/  \/_/\/_/              
+ __    __   ______   __   __   ______  ______
+/\ "-./  \ /\  __ \ /\ "-.\ \ /\__  _\/\  __ \
+\ \ \-./\ \\ \ \/\ \\ \ \-.  \\/_/\ \/\ \  __ \
+ \ \_\ \ \_\\ \_____\\ \_\\"\_\  \ \_\ \ \_\ \_\
+  \/_/  \/_/ \/_____/ \/_/ \/_/   \/_/  \/_/\/_/
     """.trimIndent()
 
     private val debug: Boolean by option(
@@ -158,10 +158,14 @@ class GenerateChangeLogCommand : CliktCommand() {
             SlackChangeLogPrinter(
                 slackToken = slackToken,
                 slackChannels = buildSet {
-                    slackChannel?.let { add(it) }
+                    slackChannel?.let {
+                        if (it.isNotBlank()) {
+                            add(it)
+                        }
+                    }
                     slackChannels?.let { list ->
                         val trimmed = list.filter {
-                            it.isNotEmpty()
+                            it.isNotBlank()
                         }
                         addAll(trimmed)
                     }

--- a/src/commonMain/kotlin/com.monta.changelog/git/sorter/SemVerSorter.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/git/sorter/SemVerSorter.kt
@@ -1,26 +1,28 @@
 package com.monta.changelog.git.sorter
 
 import com.monta.changelog.git.getTagValue
+import com.monta.changelog.util.DebugLogger
+import io.github.z4kn4fein.semver.Version
 
 class SemVerSorter : TagSorter {
 
     override fun sort(tags: List<Tag>): List<Tag> {
         return tags.mapNotNull { tag ->
             val shortTag = tag.shortTag
-            // Get the last part of the tag so stuff like releases/tag/2023-02-28-14-39 can still be valid
+            // Get the last part of the tag so stuff like releases/tag/v1.2.3 can still be valid
             var tagValue = shortTag.getTagValue()
             // Remove the V portion if it's there (Not required for sorting)
             tagValue = tagValue.replace("v", "")
-            // We check it's a valid tag by seeing it contains three dots (there is 100% a better way to do this)
-            if (shortTag.count { it == '.' } >= 2) {
-                tagValue to tag
-            } else {
+            try {
+                Version.parse(tagValue) to tag
+            } catch (e: Exception) {
+                DebugLogger.warn("Failed to parse tag '$tagValue' - ignored")
                 null
             }
         }
             // Sort by the date
-            .sortedByDescending { (localDateTime, _) ->
-                localDateTime
+            .sortedByDescending { (shortTag, _) ->
+                shortTag
             }
             // Return only the tag
             .map { (_, tag) ->

--- a/src/commonTest/kotlin/com/monta/changelog/git/sorter/SemVerSorterTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/git/sorter/SemVerSorterTest.kt
@@ -1,0 +1,22 @@
+package com.monta.changelog.git.sorter
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class SemVerSorterTest : StringSpec({
+
+    listOf(
+        listOf("5.9.0", "5.9.1") to listOf("5.9.1", "5.9.0"),
+        listOf("5.9.0", "v5.9.1") to listOf("v5.9.1", "5.9.0"),
+        listOf("4.1.1", "5.0.0") to listOf("5.0.0", "4.1.1"),
+        listOf("5.10.0", "5.0.0") to listOf("5.10.0", "5.0.0"),
+        listOf("5.10.0", "5.9.0") to listOf("5.10.0", "5.9.0"),
+        listOf("10.10.0", "5.9.0") to listOf("10.10.0", "5.9.0"),
+        listOf("10.10.0", "ignored tag", "5.9.0") to listOf("10.10.0", "5.9.0")
+    ).forEach { (input, expected) ->
+        "should sort tags in descending order" {
+            val tags = input.map { Tag(it) }
+            val sortedTags = SemVerSorter().sort(tags)
+            sortedTags shouldBe expected.map { Tag(it) }
+        }
+    }
+})


### PR DESCRIPTION
…s [ESP-13]

* fixed the small warning/bug if 'slack-channel' was left empty (the library-kotlin uses the version supporting multiple channels 'slack-channels'
* added dependency on [kotlin-semver](https://github.com/z4kn4fein/kotlin-semver)
* added test cases for the semver sorter

JIRA [ESP-13](https://montaapp.atlassian.net/browse/ESP-13)

[ESP-13]: https://montaapp.atlassian.net/browse/ESP-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ESP-13]: https://montaapp.atlassian.net/browse/ESP-13?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ