### PR TITLE
feat: resolve bot actor to real user via automerge label

### DIFF
--- a/src/commonMain/kotlin/com.monta.changelog/github/GitHubService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/github/GitHubService.kt
@@ -566,10 +566,7 @@ class GitHubService(
 
             if (response.status.isSuccess()) {
                 val events = response.body<List<IssueEvent>>()
-                val labelEvent = events.lastOrNull { event ->
-                    event.event == "labeled" && event.label?.name == labelName
-                }
-                val actor = labelEvent?.actor?.login
+                val actor = findLabelAdderFromEvents(events, labelName)
                 if (actor != null) {
                     DebugLogger.debug("Found '$labelName' label was added by: $actor")
                 } else {
@@ -613,4 +610,20 @@ class GitHubService(
         @SerialName("body")
         val body: String,
     )
+
+    companion object {
+        /**
+         * Returns true if the given actor username looks like a GitHub bot account.
+         */
+        fun isBotActor(actor: String?): Boolean = actor != null && actor.contains("[bot]")
+
+        /**
+         * Finds the username of the person who last added a specific label,
+         * given a list of issue events. Pure function for testability.
+         */
+        fun findLabelAdderFromEvents(
+            events: List<IssueEvent>,
+            labelName: String,
+        ): String? = events.lastOrNull { it.event == "labeled" && it.label?.name == labelName }?.actor?.login
+    }
 }

--- a/src/commonMain/kotlin/com.monta.changelog/github/GitHubService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/github/GitHubService.kt
@@ -539,6 +539,75 @@ class GitHubService(
         DebugLogger.warn("   →   pull-requests: write")
     }
 
+    /**
+     * Finds the GitHub username of the person who added a specific label to an issue/PR.
+     * Uses the Issues Events API to look through label events.
+     * Returns null if no token, no matching event found, or API call fails.
+     */
+    suspend fun findLabelAdder(
+        repoOwner: String,
+        repoName: String,
+        prNumber: Int,
+        labelName: String,
+    ): String? {
+        if (githubToken == null) {
+            DebugLogger.debug("No GitHub token provided, skipping label event lookup for PR #$prNumber")
+            return null
+        }
+
+        DebugLogger.debug("Querying GitHub API for who added '$labelName' label to PR #$prNumber")
+
+        return try {
+            val response = client.githubRequest<String?>(
+                path = "$repoOwner/$repoName/issues/$prNumber/events",
+                httpMethod = HttpMethod.Get,
+                body = null
+            )
+
+            if (response.status.isSuccess()) {
+                val events = response.body<List<IssueEvent>>()
+                val labelEvent = events.lastOrNull { event ->
+                    event.event == "labeled" && event.label?.name == labelName
+                }
+                val actor = labelEvent?.actor?.login
+                if (actor != null) {
+                    DebugLogger.debug("Found '$labelName' label was added by: $actor")
+                } else {
+                    DebugLogger.debug("No '$labelName' label event found on PR #$prNumber")
+                }
+                actor
+            } else {
+                DebugLogger.warn("⚠️  Failed to get events for PR #$prNumber: HTTP ${response.status.value}")
+                null
+            }
+        } catch (e: Exception) {
+            DebugLogger.warn("⚠️  Exception getting events for PR #$prNumber: ${e.message}")
+            null
+        }
+    }
+
+    @Serializable
+    data class IssueEvent(
+        @SerialName("event")
+        val event: String,
+        @SerialName("actor")
+        val actor: EventActor? = null,
+        @SerialName("label")
+        val label: EventLabel? = null,
+    )
+
+    @Serializable
+    data class EventActor(
+        @SerialName("login")
+        val login: String,
+    )
+
+    @Serializable
+    data class EventLabel(
+        @SerialName("name")
+        val name: String,
+    )
+
     @Serializable
     data class CommentRequest(
         @SerialName("body")

--- a/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
@@ -123,9 +123,33 @@ class ChangeLogService(
         // Extract PRs and their bodies from ALL commits (including merge commits)
         val prInfos = extractPullRequestsFromCommitShas(commitInfo.commits, commitInfo.allCommitShas)
 
+        // If the triggering actor is a bot, try to find the real person
+        // by looking at who added the automerge label on the most recent PR
+        val resolvedTriggeredBy = if (triggeredBy != null && triggeredBy.contains("[bot]")) {
+            val prNumber = prInfos.maxByOrNull { it.number }?.number
+            if (prNumber != null) {
+                val labelAdder = gitHubService.findLabelAdder(
+                    repoOwner = repoInfo.repoOwner,
+                    repoName = repoInfo.repoName,
+                    prNumber = prNumber,
+                    labelName = "automerge"
+                )
+                if (labelAdder != null) {
+                    DebugLogger.info("Resolved bot actor '$triggeredBy' to real user '$labelAdder' (added automerge label on PR #$prNumber)")
+                    labelAdder
+                } else {
+                    triggeredBy
+                }
+            } else {
+                triggeredBy
+            }
+        } else {
+            triggeredBy
+        }
+
         // Fetch the user's real name from GitHub if triggeredBy is provided
-        val triggeredByName = if (triggeredBy != null) {
-            gitHubService.getUserName(triggeredBy)
+        val triggeredByName = if (resolvedTriggeredBy != null) {
+            gitHubService.getUserName(resolvedTriggeredBy)
         } else {
             null
         }
@@ -193,7 +217,7 @@ class ChangeLogService(
             jiraTickets = validatedTickets,
             nonConventionalCommits = commitInfo.nonConventionalCommits,
             jobUrl = jobUrl,
-            triggeredBy = triggeredBy,
+            triggeredBy = resolvedTriggeredBy,
             triggeredByName = triggeredByName,
             dockerImage = dockerImage,
             imageTag = imageTag,

--- a/src/commonTest/kotlin/com/monta/changelog/github/GitHubServiceTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/github/GitHubServiceTest.kt
@@ -1,0 +1,108 @@
+package com.monta.changelog.github
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class GitHubServiceTest :
+    StringSpec({
+
+        "isBotActor should return true for bot actors" {
+            GitHubService.isBotActor("monta-zipper[bot]") shouldBe true
+            GitHubService.isBotActor("dependabot[bot]") shouldBe true
+            GitHubService.isBotActor("github-actions[bot]") shouldBe true
+        }
+
+        "isBotActor should return false for human actors" {
+            GitHubService.isBotActor("JesperTerkelsen") shouldBe false
+            GitHubService.isBotActor("some-user") shouldBe false
+        }
+
+        "isBotActor should return false for null" {
+            GitHubService.isBotActor(null) shouldBe false
+        }
+
+        "findLabelAdderFromEvents should find who added automerge label" {
+            val events = listOf(
+                GitHubService.IssueEvent(
+                    event = "labeled",
+                    actor = GitHubService.EventActor(login = "JesperTerkelsen"),
+                    label = GitHubService.EventLabel(name = "automerge")
+                )
+            )
+
+            GitHubService.findLabelAdderFromEvents(events, "automerge") shouldBe "JesperTerkelsen"
+        }
+
+        "findLabelAdderFromEvents should return last adder when label added multiple times" {
+            val events = listOf(
+                GitHubService.IssueEvent(
+                    event = "labeled",
+                    actor = GitHubService.EventActor(login = "user-a"),
+                    label = GitHubService.EventLabel(name = "automerge")
+                ),
+                GitHubService.IssueEvent(
+                    event = "unlabeled",
+                    actor = GitHubService.EventActor(login = "user-a"),
+                    label = GitHubService.EventLabel(name = "automerge")
+                ),
+                GitHubService.IssueEvent(
+                    event = "labeled",
+                    actor = GitHubService.EventActor(login = "user-b"),
+                    label = GitHubService.EventLabel(name = "automerge")
+                )
+            )
+
+            GitHubService.findLabelAdderFromEvents(events, "automerge") shouldBe "user-b"
+        }
+
+        "findLabelAdderFromEvents should ignore other labels" {
+            val events = listOf(
+                GitHubService.IssueEvent(
+                    event = "labeled",
+                    actor = GitHubService.EventActor(login = "some-user"),
+                    label = GitHubService.EventLabel(name = "bug")
+                ),
+                GitHubService.IssueEvent(
+                    event = "labeled",
+                    actor = GitHubService.EventActor(login = "other-user"),
+                    label = GitHubService.EventLabel(name = "enhancement")
+                )
+            )
+
+            GitHubService.findLabelAdderFromEvents(events, "automerge").shouldBeNull()
+        }
+
+        "findLabelAdderFromEvents should return null for empty events" {
+            GitHubService.findLabelAdderFromEvents(emptyList(), "automerge").shouldBeNull()
+        }
+
+        "findLabelAdderFromEvents should ignore non-labeled events" {
+            val events = listOf(
+                GitHubService.IssueEvent(
+                    event = "closed",
+                    actor = GitHubService.EventActor(login = "some-user"),
+                    label = null
+                ),
+                GitHubService.IssueEvent(
+                    event = "merged",
+                    actor = GitHubService.EventActor(login = "monta-zipper[bot]"),
+                    label = null
+                )
+            )
+
+            GitHubService.findLabelAdderFromEvents(events, "automerge").shouldBeNull()
+        }
+
+        "findLabelAdderFromEvents should handle events with null actor" {
+            val events = listOf(
+                GitHubService.IssueEvent(
+                    event = "labeled",
+                    actor = null,
+                    label = GitHubService.EventLabel(name = "automerge")
+                )
+            )
+
+            GitHubService.findLabelAdderFromEvents(events, "automerge").shouldBeNull()
+        }
+    })


### PR DESCRIPTION
## Summary
- When a deploy is triggered by a bot (e.g. `monta-zipper[bot]` via automerge), the Slack notification currently shows the bot as the deployer instead of the person who initiated it
- This change resolves the real user by querying GitHub's Issues Events API to find who added the `automerge` label on the PR
- Falls back to the bot username if no label event is found

## How it works
1. `ChangeLogService` detects if `triggeredBy` contains `[bot]`
2. Picks the highest-numbered PR from the changelog
3. Calls `GitHubService.findLabelAdder()` which queries `/repos/{owner}/{repo}/issues/{pr}/events`
4. Finds the last `labeled` event matching `automerge` and returns the actor
5. Uses that person's username (and resolves their real name) for the Slack message

## Test plan
- [ ] Deploy a repo where a bot triggered the workflow (automerge via zipper) and verify Slack shows the real user
- [ ] Deploy a repo where a human triggered the workflow and verify no change in behavior
- [ ] Deploy a repo with no automerge label and verify fallback to bot username

🤖 Generated with [Claude Code](https://claude.com/claude-code)