### PR TITLE
chore: remove gradle dependency grouping from renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,22 +5,5 @@
     ":semanticCommitTypeAll(chore)"
   ],
   "semanticCommits": "enabled",
-  "prConcurrentLimit": 2,
-  "packageRules": [
-    {
-      "groupName": "upgrade all gradle dependencies",
-      "matchManagers": [
-        "gradle"
-      ],
-      "groupSlug": "gradle",
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "major"
-      ],
-      "matchPackageNames": [
-        "*"
-      ]
-    }
-  ]
+  "prConcurrentLimit": 2
 }


### PR DESCRIPTION
## Summary
- Remove the `packageRules` grouping that bundles all Gradle dependencies into a single PR
- Renovate will now create individual PRs per dependency, enabling incremental updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)