### PR TITLE
feat: add build and revert conventional commit types

### DIFF
--- a/src/commonMain/kotlin/com.monta.changelog/model/ConventionalCommitType.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/model/ConventionalCommitType.kt
@@ -60,6 +60,18 @@ enum class ConventionalCommitType(
         sortOrder = 8,
         values = listOf("ci")
     ),
+    Build(
+        title = "Build",
+        emoji = "\uD83D\uDCE6",
+        sortOrder = 9,
+        values = listOf("build")
+    ),
+    Revert(
+        title = "Revert",
+        emoji = "\u23EA",
+        sortOrder = 10,
+        values = listOf("revert")
+    ),
     ;
 
     companion object {

--- a/src/commonTest/kotlin/com/monta/changelog/git/CommitMapperTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/git/CommitMapperTest.kt
@@ -1,5 +1,6 @@
 package com.monta.changelog.git
 
+import com.monta.changelog.model.ConventionalCommitType
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -105,6 +106,41 @@ class CommitMapperTest :
             val commit = mapper.fromGitLogItem(logItem)
 
             commit.shouldBeNull()
+        }
+
+        "should map build commit type" {
+            val logItem = LogItem(
+                author = Author(date = "2026-01-12", email = "test@test.com", name = "Test"),
+                committer = Author(date = "2026-01-12", email = "test@test.com", name = "Test"),
+                commit = "abc123",
+                subject = "build(deps): bump kotlin to 2.0",
+                body = "",
+                parents = "parent1"
+            )
+
+            val commit = mapper.fromGitLogItem(logItem)
+
+            commit.shouldNotBeNull()
+            commit.type shouldBe ConventionalCommitType.Build
+            commit.scope shouldBe "deps"
+            commit.message shouldBe "bump kotlin to 2.0"
+        }
+
+        "should map revert commit type" {
+            val logItem = LogItem(
+                author = Author(date = "2026-01-12", email = "test@test.com", name = "Test"),
+                committer = Author(date = "2026-01-12", email = "test@test.com", name = "Test"),
+                commit = "abc123",
+                subject = "revert: undo previous change",
+                body = "",
+                parents = "parent1"
+            )
+
+            val commit = mapper.fromGitLogItem(logItem)
+
+            commit.shouldNotBeNull()
+            commit.type shouldBe ConventionalCommitType.Revert
+            commit.message shouldBe "undo previous change"
         }
 
         "should map commit with double quotes in subject" {


### PR DESCRIPTION
## Summary

Adds the two Conventional Commits types that were missing from `ConventionalCommitType`:

- `build` — build system / dependency changes (📦, sortOrder 9)
- `revert` — reverts of prior commits (⏪, sortOrder 10)

The CLI previously covered 9 of the 11 types in the [Conventional Commits / Angular convention](https://www.conventionalcommits.org/en/v1.0.0/). Commits like `build(deps): bump kotlin` or `revert: undo X` were being bucketed into "Non-Conventional Commits" in changelogs.

## Changes

- `ConventionalCommitType.kt` — two new enum entries
- `CommitMapperTest.kt` — tests verifying both types parse correctly (including scope on `build(deps): …`)

## Test plan

- [x] `./gradlew allTests` passes
- [x] `./gradlew ktlintCheck` passes
- [ ] Verify a real `build:` or `revert:` commit gets categorized correctly in a changelog

🤖 Generated with [Claude Code](https://claude.com/claude-code)