### PR TITLE
chore: don't tag release trigger user & use redirect.github.com for PR links in comments

### DIFF
--- a/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
@@ -602,14 +602,6 @@ class ChangeLogService(
         if (links.isNotEmpty()) {
             append(" • ${links.joinToString(" • ")}")
         }
-
-        changeLog.triggeredBy?.let { triggeredBy ->
-            val username = triggeredBy.removePrefix("@")
-            val displayText = changeLog.triggeredByName?.let {
-                "$it ([@$username](https://github.com/$username))"
-            } ?: "[@$username](https://github.com/$username)"
-            append(" • $displayText")
-        }
     }
 
     /**

--- a/src/commonMain/kotlin/com.monta.changelog/util/LinkResolver.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/util/LinkResolver.kt
@@ -47,7 +47,7 @@ sealed interface LinkResolver {
                 )
             }
 
-        private fun getUrl(ownerName: String, serviceName: String, pullRequestNumber: String): String = "https://github.com/$ownerName/$serviceName/pull/$pullRequestNumber"
+        private fun getUrl(ownerName: String, serviceName: String, pullRequestNumber: String): String = "https://redirect.github.com/$ownerName/$serviceName/pull/$pullRequestNumber"
     }
 
     class Jira(

--- a/src/commonTest/kotlin/com/monta/changelog/util/LinkResolverTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/util/LinkResolverTest.kt
@@ -69,8 +69,8 @@ class LinkResolverTest :
                 message = "Merge #123 and #456"
             )
 
-            result shouldContain "<https://github.com/monta-app/changelog-cli/pull/123|#123>"
-            result shouldContain "<https://github.com/monta-app/changelog-cli/pull/456|#456>"
+            result shouldContain "<https://redirect.github.com/monta-app/changelog-cli/pull/123|#123>"
+            result shouldContain "<https://redirect.github.com/monta-app/changelog-cli/pull/456|#456>"
         }
 
         "should not create hyperlinks for invalid PRs" {
@@ -86,11 +86,11 @@ class LinkResolverTest :
             )
 
             // #123 should be hyperlinked
-            result shouldContain "<https://github.com/monta-app/changelog-cli/pull/123|#123>"
+            result shouldContain "<https://redirect.github.com/monta-app/changelog-cli/pull/123|#123>"
 
             // #999 should remain as plain text (not hyperlinked)
             result shouldContain "#999"
-            result shouldNotContain "https://github.com/monta-app/changelog-cli/pull/999"
+            result shouldNotContain "https://redirect.github.com/monta-app/changelog-cli/pull/999"
         }
 
         "should create hyperlinks for all PRs when validPullRequests is null" {
@@ -106,8 +106,8 @@ class LinkResolverTest :
             )
 
             // Both should be hyperlinked when validation is disabled
-            result shouldContain "<https://github.com/monta-app/changelog-cli/pull/123|#123>"
-            result shouldContain "<https://github.com/monta-app/changelog-cli/pull/999|#999>"
+            result shouldContain "<https://redirect.github.com/monta-app/changelog-cli/pull/123|#123>"
+            result shouldContain "<https://redirect.github.com/monta-app/changelog-cli/pull/999|#999>"
         }
 
         "should handle multiple JIRA tickets in one message" {
@@ -139,9 +139,9 @@ class LinkResolverTest :
                 message = "Merge #10 #20 and #99"
             )
 
-            result shouldContain "<https://github.com/monta-app/test-repo/pull/10|#10>"
-            result shouldContain "<https://github.com/monta-app/test-repo/pull/20|#20>"
+            result shouldContain "<https://redirect.github.com/monta-app/test-repo/pull/10|#10>"
+            result shouldContain "<https://redirect.github.com/monta-app/test-repo/pull/20|#20>"
             result shouldContain "#99"
-            result shouldNotContain "https://github.com/monta-app/test-repo/pull/99"
+            result shouldNotContain "https://redirect.github.com/monta-app/test-repo/pull/99"
         }
     })


### PR DESCRIPTION
## What

Two adjustments to the production-release comment posted on PRs (and JIRA tickets) by the changelog CLI:

1. **Stop tagging the release-trigger user.** The comment footer appended the person who triggered the release, e.g. `• Jan Keller ([@MithrandirDK](https://github.com/MithrandirDK))`. That `@`-mentions an unrelated user on every PR included in the release. The `triggeredBy`/`triggeredByName` footer segment is removed from the GitHub/JIRA comment footer (`buildCommentFooter`).

2. **Use `redirect.github.com` for inline PR links.** Inline `#NNNN` PR references in the changelog body were linked as `https://github.com/<owner>/<repo>/pull/<n>`, which makes GitHub create cross-reference backlinks between all the PRs in a release. They now link via `https://redirect.github.com/...` (GitHub's own redirector) so no cross-references are created.

### Example

Before:
> *Released to **Production** • ⏳ Deployment pending* • [Repository](…) • [Changeset](…) • [Job](…) • [Slack](…) • Jan Keller ([@MithrandirDK](https://github.com/MithrandirDK))
>
> - harden regularly-failing jobs (NOJIRA) ([#24249](https://github.com/monta-app/server/pull/24249))

After:
> *Released to **Production** • ⏳ Deployment pending* • [Repository](…) • [Changeset](…) • [Job](…) • [Slack](…)
>
> - harden regularly-failing jobs (NOJIRA) ([#24249](https://redirect.github.com/monta-app/server/pull/24249))

## Scope notes

- `triggeredBy`/`triggeredByName` are still used for Slack output and bot-actor resolution — only the GitHub/JIRA comment footer stops rendering them.
- The Slack PR *attachment* list builds its URLs from `repositoryUrl` directly (not via `LinkResolver`), so it is unaffected; the `redirect.github.com` change applies to inline `#NNNN` references resolved by `LinkResolver.Github`.

## Testing

`./gradlew ktlintCheck jvmTest` — BUILD SUCCESSFUL. Updated `LinkResolverTest` assertions to the new host.