### PR TITLE
feat(notify): add Slack release notifications [CPONETOPS-1176]

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,40 @@ CHANGELOG_STAGE # Deployment stage/environment (e.g., dev, staging, production) 
 CHANGELOG_DOCKER_IMAGE # Docker image repository URL (e.g., 077199819609.dkr.ecr.eu-west-1.amazonaws.com/geo-production) (shown in Slack metadata) [optional]
 CHANGELOG_IMAGE_TAG # Current Docker image tag being deployed (e.g., commit SHA) (shown in Slack metadata) [optional]
 CHANGELOG_PREVIOUS_IMAGE_TAG # Previous Docker image tag for rollback reference (shown in Slack metadata) [optional]
+CHANGELOG_MONITORING_URLS # Comma-separated list of dashboard/monitoring URLs for the release notification. Each entry is a bare URL or 'Label|https://url' [optional]
+CHANGELOG_RELEASE_NOTIFY_CHANNEL # Slack channel ID or name to post a release notification to, tagging PR authors/approvers and linking the monitoring URLs [optional, requires CHANGELOG_SLACK_TOKEN]
 ```
 
 At least one of `CHANGELOG_SLACK_CHANNEL_NAME` and `CHANGELOG_SLACK_CHANNELS` is required if output is set to `slack`
+
+### Release Notifications
+
+Independently of `CHANGELOG_OUTPUT`, you can have the CLI post a short Slack message announcing the release,
+listing dashboards to keep an eye on, and tagging the people who authored or approved the pull requests included
+in it:
+
+```shell
+CHANGELOG_RELEASE_NOTIFY_CHANNEL=C02PDBL6GAU
+CHANGELOG_SLACK_TOKEN=xoxb-...
+CHANGELOG_MONITORING_URLS="Grafana|https://grafana.example.com/d/abc,Sentry|https://sentry.example.com/my-project"
+```
+
+The message looks roughly like:
+
+```
+Release <link to the GitHub release> is out 🚀
+Dashboards to monitor:
+• Grafana
+• Sentry
+Contributors:
+• @alice #123 #124
+• @bob (approver) #125
+```
+
+Contributors are tagged with a real Slack mention (`@user`) when their public GitHub email matches a Slack
+account; otherwise they're linked to their GitHub profile instead. Anyone who only approved a pull request
+(and didn't author one in this release) is suffixed with `(approver)`. Requires `CHANGELOG_GITHUB_TOKEN` to
+resolve PR authors/approvers.
 
 ### How to Release This Project
 

--- a/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
@@ -140,6 +140,23 @@ class GenerateChangeLogCommand : CliktCommand() {
         envvar = "CHANGELOG_COMMENT_ON_JIRA"
     ).flag(default = false)
 
+    private val monitoringUrls: List<String>? by option(
+        help = "Comma-separated list of dashboard/monitoring URLs to post in the release notification. " +
+            "Each entry can be a bare URL or 'Label|https://url' (optional)",
+        envvar = "CHANGELOG_MONITORING_URLS"
+    ).split(",")
+
+    private val releaseNotifyChannel: String? by option(
+        help = "Slack channel ID or name to post a release notification to, tagging PR authors/approvers and " +
+            "linking the monitoring URLs (optional, requires CHANGELOG_SLACK_TOKEN)",
+        envvar = "CHANGELOG_RELEASE_NOTIFY_CHANNEL"
+    )
+
+    private val releaseNotifySlackToken: String? by option(
+        help = "Slack token used for posting the release notification message (falls back to the token used for --output slack)",
+        envvar = "CHANGELOG_SLACK_TOKEN"
+    )
+
     private val output: PrintingConfig by option(
         help = "Name of the output used for printing the log (defaults to console)",
         envvar = "CHANGELOG_OUTPUT"
@@ -182,7 +199,10 @@ class GenerateChangeLogCommand : CliktCommand() {
                 deploymentEndTime = deploymentEndTime.valueOrNull(),
                 deploymentUrl = deploymentUrl.valueOrNull(),
                 commentOnPrs = commentOnPrs,
-                commentOnJira = commentOnJira
+                commentOnJira = commentOnJira,
+                monitoringUrls = monitoringUrls?.filter { it.isNotBlank() },
+                releaseNotifyChannel = releaseNotifyChannel.valueOrNull(),
+                releaseNotifySlackToken = releaseNotifySlackToken.valueOrNull()
             )
 
             val commitShaOptions = commitShaOptions

--- a/src/commonMain/kotlin/com.monta.changelog/github/GitHubService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/github/GitHubService.kt
@@ -389,6 +389,167 @@ class GitHubService(
     )
 
     /**
+     * Gets the full GitHub user profile (including public email, if any) for a username.
+     * Returns null if no token is provided or if the API call fails.
+     */
+    suspend fun getUser(username: String): UserResponse? {
+        if (githubToken == null) {
+            DebugLogger.debug("No GitHub token provided, skipping user lookup for $username")
+            return null
+        }
+
+        val cleanUsername = username.removePrefix("@")
+
+        return try {
+            val response = client.githubRequest<String?>(
+                path = "../users/$cleanUsername",
+                httpMethod = HttpMethod.Get,
+                body = null
+            )
+
+            if (response.status.isSuccess()) {
+                response.body<UserResponse>()
+            } else {
+                DebugLogger.debug("Could not look up GitHub user $cleanUsername: HTTP ${response.status.value}")
+                null
+            }
+        } catch (e: Exception) {
+            DebugLogger.debug("Exception looking up GitHub user $cleanUsername: ${e.message}")
+            null
+        }
+    }
+
+    /**
+     * Represents a pull request's author and its approvers, used for tagging
+     * people in release notifications.
+     */
+    data class PullRequestDetails(
+        val number: Int,
+        val author: String?,
+        val htmlUrl: String?,
+        val approvers: List<String>,
+    )
+
+    /**
+     * Gets the author and list of users who approved the given pull request.
+     * Returns empty/null values if no token is provided or if the API calls fail.
+     */
+    suspend fun getPullRequestDetails(
+        repoOwner: String,
+        repoName: String,
+        prNumber: Int,
+    ): PullRequestDetails {
+        if (githubToken == null) {
+            DebugLogger.debug("No GitHub token provided, skipping PR detail lookup for #$prNumber")
+            return PullRequestDetails(number = prNumber, author = null, htmlUrl = null, approvers = emptyList())
+        }
+
+        val (author, htmlUrl) = try {
+            val response = client.githubRequest<String?>(
+                path = "$repoOwner/$repoName/pulls/$prNumber",
+                httpMethod = HttpMethod.Get,
+                body = null
+            )
+
+            if (response.status.isSuccess()) {
+                val pr = response.body<PullRequestDetailResponse>()
+                pr.user?.login to pr.htmlUrl
+            } else {
+                DebugLogger.warn("⚠️  Failed to get PR #$prNumber details: HTTP ${response.status.value}")
+                null to null
+            }
+        } catch (e: Exception) {
+            DebugLogger.warn("⚠️  Exception getting PR #$prNumber details: ${e.message}")
+            null to null
+        }
+
+        val approvers = try {
+            val response = client.githubRequest<String?>(
+                path = "$repoOwner/$repoName/pulls/$prNumber/reviews",
+                httpMethod = HttpMethod.Get,
+                body = null
+            )
+
+            if (response.status.isSuccess()) {
+                response.body<List<PullRequestReviewResponse>>()
+                    .filter { it.state == "APPROVED" }
+                    .mapNotNull { it.user?.login }
+                    .distinct()
+            } else {
+                DebugLogger.warn("⚠️  Failed to get reviews for PR #$prNumber: HTTP ${response.status.value}")
+                emptyList()
+            }
+        } catch (e: Exception) {
+            DebugLogger.warn("⚠️  Exception getting reviews for PR #$prNumber: ${e.message}")
+            emptyList()
+        }
+
+        return PullRequestDetails(number = prNumber, author = author, htmlUrl = htmlUrl, approvers = approvers)
+    }
+
+    @Serializable
+    data class PullRequestDetailResponse(
+        @SerialName("html_url")
+        val htmlUrl: String? = null,
+        @SerialName("user")
+        val user: EventActor? = null,
+    )
+
+    @Serializable
+    data class PullRequestReviewResponse(
+        @SerialName("state")
+        val state: String? = null,
+        @SerialName("user")
+        val user: EventActor? = null,
+    )
+
+    /**
+     * Gets the commit messages (subject + body) for every commit in a pull request.
+     * Used to detect `Co-authored-by:` trailers. Returns an empty list if no token is
+     * provided or if the API call fails.
+     */
+    suspend fun getPullRequestCommitMessages(
+        repoOwner: String,
+        repoName: String,
+        prNumber: Int,
+    ): List<String> {
+        if (githubToken == null) {
+            DebugLogger.debug("No GitHub token provided, skipping commit lookup for PR #$prNumber")
+            return emptyList()
+        }
+
+        return try {
+            val response = client.githubRequest<String?>(
+                path = "$repoOwner/$repoName/pulls/$prNumber/commits",
+                httpMethod = HttpMethod.Get,
+                body = null
+            )
+
+            if (response.status.isSuccess()) {
+                response.body<List<PullRequestCommitResponse>>().mapNotNull { it.commit?.message }
+            } else {
+                DebugLogger.warn("⚠️  Failed to get commits for PR #$prNumber: HTTP ${response.status.value}")
+                emptyList()
+            }
+        } catch (e: Exception) {
+            DebugLogger.warn("⚠️  Exception getting commits for PR #$prNumber: ${e.message}")
+            emptyList()
+        }
+    }
+
+    @Serializable
+    data class PullRequestCommitResponse(
+        @SerialName("commit")
+        val commit: PullRequestCommitDetail? = null,
+    )
+
+    @Serializable
+    data class PullRequestCommitDetail(
+        @SerialName("message")
+        val message: String? = null,
+    )
+
+    /**
      * Checks if a pull request exists in the repository.
      * Returns true if the PR exists and is accessible, false otherwise.
      */

--- a/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
@@ -5,6 +5,8 @@ import com.monta.changelog.git.GitService
 import com.monta.changelog.git.sorter.TagSorter
 import com.monta.changelog.github.GitHubService
 import com.monta.changelog.model.ChangeLog
+import com.monta.changelog.notify.MonitoringUrl
+import com.monta.changelog.notify.ReleaseNotificationService
 import com.monta.changelog.printer.ChangeLogPrinter
 import com.monta.changelog.util.DateTimeUtil
 import com.monta.changelog.util.DebugLogger
@@ -35,6 +37,9 @@ class ChangeLogService(
     private val deploymentUrl: String?,
     private val commentOnPrs: Boolean,
     private val commentOnJira: Boolean,
+    private val monitoringUrls: List<String>? = null,
+    private val releaseNotifyChannel: String? = null,
+    private val releaseNotifySlackToken: String? = null,
 ) {
 
     private val gitService = GitService(tagSorter, tagPattern, pathExcludePattern)
@@ -46,6 +51,17 @@ class ChangeLogService(
     }
     private val repoInfo = gitService.getRepoInfo()
     private val repositoryUrl = gitService.getRepositoryUrl()
+
+    private val releaseNotificationService = if (releaseNotifyChannel != null && releaseNotifySlackToken != null) {
+        ReleaseNotificationService(
+            slackToken = releaseNotifySlackToken,
+            slackChannel = releaseNotifyChannel,
+            monitoringUrls = MonitoringUrl.parseAll(monitoringUrls),
+            gitHubService = gitHubService
+        )
+    } else {
+        null
+    }
 
     private fun linkResolvers(
         validatedTickets: List<String>? = null,
@@ -82,6 +98,10 @@ class ChangeLogService(
         }
         if (pathExcludePattern != null) {
             DebugLogger.info("pathExclude   $pathExcludePattern")
+        }
+        if (releaseNotifyChannel != null && releaseNotifySlackToken == null) {
+            DebugLogger.warn("⚠️  Release notify channel is set but no Slack token was provided")
+            DebugLogger.warn("   → Set CHANGELOG_SLACK_TOKEN to enable the release notification message")
         }
     }
 
@@ -235,6 +255,13 @@ class ChangeLogService(
                     validatedPrs = validatedPrs
                 ),
                 changeLog = changeLog
+            )
+        }
+
+        if (releaseNotificationService != null) {
+            releaseNotificationService.notify(
+                changeLog = changeLog,
+                pullRequests = validatedPrs
             )
         }
 

--- a/src/commonMain/kotlin/com.monta.changelog/notify/CoAuthorExtractor.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/notify/CoAuthorExtractor.kt
@@ -1,0 +1,31 @@
+package com.monta.changelog.notify
+
+/**
+ * Extracts `Co-authored-by: Name <email>` trailers from commit messages, as added by
+ * GitHub (and `git commit --amend --author`/`-m` conventions) when a commit has multiple authors.
+ */
+internal object CoAuthorExtractor {
+
+    private val coAuthorRegex = Regex("(?im)^co-authored-by:\\s*(.+?)\\s*<([^>]+)>\\s*$")
+
+    // GitHub's noreply commit email, e.g. "12345678+username@users.noreply.github.com"
+    private val githubNoreplyRegex = Regex("^(?:\\d+\\+)?([A-Za-z0-9-]+)@users\\.noreply\\.github\\.com$", RegexOption.IGNORE_CASE)
+
+    data class CoAuthor(
+        val name: String,
+        val email: String,
+        val login: String?,
+    )
+
+    fun extract(commitMessages: List<String>): List<CoAuthor> = commitMessages
+        .flatMap { message ->
+            coAuthorRegex.findAll(message).map { match ->
+                match.groupValues[1].trim() to match.groupValues[2].trim()
+            }
+        }
+        .distinct()
+        .map { (name, email) ->
+            val login = githubNoreplyRegex.find(email)?.groupValues?.get(1)
+            CoAuthor(name = name, email = email, login = login)
+        }
+}

--- a/src/commonMain/kotlin/com.monta.changelog/notify/MonitoringUrl.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/notify/MonitoringUrl.kt
@@ -1,0 +1,36 @@
+package com.monta.changelog.notify
+
+/**
+ * A labeled URL (e.g. a dashboard or monitoring link) to include in a release notification.
+ */
+data class MonitoringUrl(
+    val label: String,
+    val url: String,
+) {
+    companion object {
+        /**
+         * Parses a single monitoring URL entry, supporting either a bare URL
+         * (`https://example.com`) or a labeled one (`Label|https://example.com`).
+         */
+        fun parse(raw: String): MonitoringUrl? {
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) {
+                return null
+            }
+
+            val parts = trimmed.split("|", limit = 2)
+            return if (parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()) {
+                MonitoringUrl(label = parts[0].trim(), url = parts[1].trim())
+            } else {
+                MonitoringUrl(label = trimmed, url = trimmed)
+            }
+        }
+
+        /**
+         * Parses a comma-separated list of monitoring URL entries.
+         */
+        fun parseAll(raw: List<String>?): List<MonitoringUrl> = raw
+            ?.mapNotNull(::parse)
+            ?: emptyList()
+    }
+}

--- a/src/commonMain/kotlin/com.monta.changelog/notify/ReleaseNotificationService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/notify/ReleaseNotificationService.kt
@@ -10,9 +10,13 @@ import com.monta.changelog.printer.slack.SlackUserResolver
 import com.monta.changelog.util.DebugLogger
 import com.monta.changelog.util.client
 import com.monta.changelog.util.getBodySafe
-import io.ktor.client.request.*
-import io.ktor.http.*
-import io.ktor.utils.io.charsets.*
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.charsets.name
 
 /**
  * A single person contributing to the release, tracked by the most specific identity

--- a/src/commonMain/kotlin/com.monta.changelog/notify/ReleaseNotificationService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/notify/ReleaseNotificationService.kt
@@ -1,0 +1,284 @@
+package com.monta.changelog.notify
+
+import com.monta.changelog.github.GitHubService
+import com.monta.changelog.model.ChangeLog
+import com.monta.changelog.printer.slack.SlackBlock
+import com.monta.changelog.printer.slack.SlackMessageRequest
+import com.monta.changelog.printer.slack.SlackMessageResponse
+import com.monta.changelog.printer.slack.SlackText
+import com.monta.changelog.printer.slack.SlackUserResolver
+import com.monta.changelog.util.DebugLogger
+import com.monta.changelog.util.client
+import com.monta.changelog.util.getBodySafe
+import io.ktor.client.request.*
+import io.ktor.http.*
+import io.ktor.utils.io.charsets.*
+
+/**
+ * A single person contributing to the release, tracked by the most specific identity
+ * we have for them (GitHub login, otherwise email, otherwise their commit trailer name).
+ */
+internal data class Contributor(
+    val login: String?,
+    val email: String?,
+    val displayName: String,
+    val prNumbers: MutableSet<Int> = mutableSetOf(),
+    var isAuthor: Boolean = false,
+    var isApprover: Boolean = false,
+    var isCoAuthor: Boolean = false,
+) {
+    val key: String get() = (login ?: email ?: displayName).lowercase()
+}
+
+/**
+ * Adds or updates a contributor for a given PR, skipping bot accounts (matched on GitHub
+ * login or the commit trailer display name, since bot co-authors rarely have a resolvable login).
+ * Returns silently if there's no usable identity at all.
+ */
+internal fun addContributor(
+    contributors: MutableMap<String, Contributor>,
+    login: String? = null,
+    email: String? = null,
+    displayName: String? = null,
+    prNumber: Int,
+    markRole: (Contributor) -> Unit,
+) {
+    val resolvedDisplayName = displayName ?: login ?: email ?: return
+    if (GitHubService.isBotActor(login) || GitHubService.isBotActor(resolvedDisplayName)) {
+        return
+    }
+
+    val contributor = Contributor(login = login, email = email, displayName = resolvedDisplayName)
+    val existing = contributors.getOrPut(contributor.key) { contributor }
+    existing.prNumbers.add(prNumber)
+    markRole(existing)
+}
+
+/**
+ * Orders contributors so that people who wrote code (authors/co-authors) come before
+ * people who only approved, and alphabetically within each group.
+ */
+internal fun sortContributors(contributors: Collection<Contributor>): List<Contributor> = contributors
+    .sortedWith(
+        compareBy(
+            { contributor -> !contributor.isAuthor && !contributor.isCoAuthor && contributor.isApprover },
+            { contributor -> contributor.displayName.lowercase() }
+        )
+    )
+
+/**
+ * Builds the "(co-author, approver)" style suffix for a contributor's secondary roles.
+ * Authors get no suffix - being the author is the default, unqualified role.
+ */
+internal fun buildRoleSuffix(contributor: Contributor): String {
+    val roles = buildList {
+        if (contributor.isCoAuthor) add("co-author")
+        if (contributor.isApprover) add("approver")
+    }
+    return if (!contributor.isAuthor && roles.isNotEmpty()) " (${roles.joinToString(", ")})" else ""
+}
+
+/**
+ * Builds the space-separated list of linked PR numbers a contributor participated in.
+ */
+internal fun buildPrLinks(
+    repoOwner: String,
+    repoName: String,
+    prNumbers: Set<Int>,
+    prUrls: Map<Int, String?>,
+): String = prNumbers.sorted().joinToString(" ") { prNumber ->
+    val url = prUrls[prNumber] ?: "https://github.com/$repoOwner/$repoName/pull/$prNumber"
+    "<$url|#$prNumber>"
+}
+
+/**
+ * Formats a resolved Slack mention, falling back to a GitHub profile link when no Slack
+ * account was found, and to a plain display name when there's no GitHub login either.
+ */
+internal fun formatMention(slackUserId: String?, login: String?, displayName: String): String = when {
+    slackUserId != null -> "<@$slackUserId>"
+    login != null -> "<https://github.com/$login|@$login>"
+    else -> displayName
+}
+
+/**
+ * Builds the "• <mention> (role) <pr links>" line for a single contributor.
+ */
+internal fun buildMentionLine(
+    repoOwner: String,
+    repoName: String,
+    contributor: Contributor,
+    prUrls: Map<Int, String?>,
+    mention: String,
+): String {
+    val roleSuffix = buildRoleSuffix(contributor)
+    val links = buildPrLinks(repoOwner, repoName, contributor.prNumbers, prUrls)
+    return "• $mention$roleSuffix $links"
+}
+
+/**
+ * Walks every pull request in the release, collecting authors, approvers and
+ * `Co-authored-by:` trailers into a single contributor map (bots excluded). The fetchers
+ * are injected so this orchestration can be unit tested without hitting the GitHub API.
+ */
+internal suspend fun buildContributors(
+    prNumbers: List<Int>,
+    getPullRequestDetails: suspend (Int) -> GitHubService.PullRequestDetails,
+    getPullRequestCommitMessages: suspend (Int) -> List<String>,
+): Pair<Map<String, Contributor>, Map<Int, String?>> {
+    val contributors = mutableMapOf<String, Contributor>()
+    val prUrls = mutableMapOf<Int, String?>()
+
+    prNumbers.forEach { prNumber ->
+        val details = getPullRequestDetails(prNumber)
+        prUrls[prNumber] = details.htmlUrl
+
+        details.author?.let { author ->
+            addContributor(contributors, login = author, prNumber = prNumber) { it.isAuthor = true }
+        }
+        details.approvers.forEach { approver ->
+            addContributor(contributors, login = approver, prNumber = prNumber) { it.isApprover = true }
+        }
+
+        val commitMessages = getPullRequestCommitMessages(prNumber)
+        CoAuthorExtractor.extract(commitMessages).forEach { coAuthor ->
+            addContributor(
+                contributors,
+                login = coAuthor.login,
+                email = coAuthor.email,
+                displayName = coAuthor.name,
+                prNumber = prNumber
+            ) { it.isCoAuthor = true }
+        }
+    }
+
+    return contributors to prUrls
+}
+
+/**
+ * True when there's nothing worth posting a release notification for.
+ */
+internal fun shouldSkipNotification(
+    prNumbers: List<Int>,
+    monitoringUrls: List<MonitoringUrl>,
+): Boolean = prNumbers.isEmpty() && monitoringUrls.isEmpty()
+
+/**
+ * Builds the Slack blocks for the release notification: release link, dashboards to
+ * monitor and the contributor list, each section omitted when there's nothing to show.
+ */
+internal fun buildReleaseNotificationBlocks(
+    changeLog: ChangeLog,
+    monitoringUrls: List<MonitoringUrl>,
+    mentionLines: List<String>,
+): List<SlackBlock> = buildList {
+    val releaseUrl = changeLog.githubReleaseUrl
+        ?: changeLog.repositoryUrl?.let { "$it/releases/tag/${changeLog.tagName}" }
+    val releaseText = if (releaseUrl != null) {
+        "*Release <$releaseUrl|${changeLog.tagName}>* is out :rocket:"
+    } else {
+        "*Release ${changeLog.tagName}* is out :rocket:"
+    }
+    add(sectionBlock(releaseText))
+
+    if (monitoringUrls.isNotEmpty()) {
+        val dashboardLines = monitoringUrls.joinToString("\n") { "• <${it.url}|${it.label}>" }
+        add(sectionBlock("*Dashboards to monitor:*\n$dashboardLines"))
+    }
+
+    if (mentionLines.isNotEmpty()) {
+        add(sectionBlock("*Contributors:*\n${mentionLines.joinToString("\n")}"))
+    }
+}
+
+private fun sectionBlock(text: String) = SlackBlock(
+    type = "section",
+    text = SlackText(type = "mrkdwn", text = text)
+)
+
+/**
+ * Posts a standalone Slack message announcing a release, listing dashboards to monitor
+ * and tagging the people who authored, co-authored or approved the pull requests included in it.
+ */
+class ReleaseNotificationService(
+    private val slackToken: String,
+    private val slackChannel: String,
+    private val monitoringUrls: List<MonitoringUrl>,
+    private val gitHubService: GitHubService,
+) {
+
+    suspend fun notify(
+        changeLog: ChangeLog,
+        pullRequests: List<String>,
+    ) {
+        val prNumbers = pullRequests.mapNotNull { it.toIntOrNull() }
+
+        if (shouldSkipNotification(prNumbers, monitoringUrls)) {
+            DebugLogger.debug("Skipping release notification - no pull requests or monitoring URLs to report")
+            return
+        }
+
+        val (contributors, prUrls) = buildContributors(
+            prNumbers = prNumbers,
+            getPullRequestDetails = { prNumber ->
+                gitHubService.getPullRequestDetails(
+                    repoOwner = changeLog.repoOwner,
+                    repoName = changeLog.repoName,
+                    prNumber = prNumber
+                )
+            },
+            getPullRequestCommitMessages = { prNumber ->
+                gitHubService.getPullRequestCommitMessages(
+                    repoOwner = changeLog.repoOwner,
+                    repoName = changeLog.repoName,
+                    prNumber = prNumber
+                )
+            }
+        )
+
+        val mentionLines = sortContributors(contributors.values).map { contributor ->
+            buildMentionLine(
+                repoOwner = changeLog.repoOwner,
+                repoName = changeLog.repoName,
+                contributor = contributor,
+                prUrls = prUrls,
+                mention = resolveMention(contributor)
+            )
+        }
+
+        postMessage(
+            blocks = buildReleaseNotificationBlocks(changeLog, monitoringUrls, mentionLines),
+            fallbackText = changeLog.title
+        )
+    }
+
+    /**
+     * Resolves a contributor to a real Slack mention by looking up their public GitHub
+     * email (or commit trailer email) in Slack.
+     */
+    private suspend fun resolveMention(contributor: Contributor): String {
+        val email = contributor.email ?: contributor.login?.let { gitHubService.getUser(it)?.email }
+        val slackUserId = email?.let { SlackUserResolver.lookupUserIdByEmail(slackToken, it) }
+        return formatMention(slackUserId = slackUserId, login = contributor.login, displayName = contributor.displayName)
+    }
+
+    private suspend fun postMessage(blocks: List<SlackBlock>, fallbackText: String) {
+        val response = client.post("https://slack.com/api/chat.postMessage") {
+            header("Authorization", "Bearer $slackToken")
+            contentType(ContentType.Application.Json.withParameter("charset", Charsets.UTF_8.name))
+            setBody(
+                SlackMessageRequest(
+                    channel = slackChannel,
+                    threadTs = null,
+                    text = fallbackText,
+                    blocks = blocks
+                )
+            )
+        }
+
+        val result = response.getBodySafe<SlackMessageResponse>()
+        if (result?.ok != true) {
+            DebugLogger.error("Could not post release notification to slack channel '$slackChannel'")
+        }
+    }
+}

--- a/src/commonMain/kotlin/com.monta.changelog/printer/slack/SlackUserResolver.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/printer/slack/SlackUserResolver.kt
@@ -3,7 +3,8 @@ package com.monta.changelog.printer.slack
 import com.monta.changelog.util.DebugLogger
 import com.monta.changelog.util.client
 import com.monta.changelog.util.getBodySafe
-import io.ktor.client.request.*
+import io.ktor.client.request.get
+import io.ktor.client.request.header
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 

--- a/src/commonMain/kotlin/com.monta.changelog/printer/slack/SlackUserResolver.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/printer/slack/SlackUserResolver.kt
@@ -1,0 +1,50 @@
+package com.monta.changelog.printer.slack
+
+import com.monta.changelog.util.DebugLogger
+import com.monta.changelog.util.client
+import com.monta.changelog.util.getBodySafe
+import io.ktor.client.request.*
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Resolves Slack user IDs from an email address, used to @mention GitHub
+ * contributors who share their public email address with Slack.
+ */
+internal object SlackUserResolver {
+    suspend fun lookupUserIdByEmail(slackToken: String, email: String): String? {
+        val response = client.get("https://slack.com/api/users.lookupByEmail") {
+            header("Authorization", "Bearer $slackToken")
+            url {
+                parameters.append("email", email)
+            }
+        }
+
+        val result = response.getBodySafe<SlackUserLookupResponse>()
+        if (result?.ok == true && result.user?.id != null) {
+            return result.user.id
+        }
+
+        if (result?.error != null && result.error != "users_not_found") {
+            DebugLogger.warn("⚠️  Slack user lookup failed for $email: ${result.error}")
+        }
+
+        return null
+    }
+}
+
+@Serializable
+internal data class SlackUserLookupResponse(
+    @SerialName("ok")
+    val ok: Boolean,
+    @SerialName("error")
+    val error: String? = null,
+    @SerialName("user")
+    val user: SlackUserLookupResult? = null,
+)
+
+@Serializable
+internal data class SlackUserLookupResult(
+    @SerialName("id")
+    val id: String? = null,
+)

--- a/src/commonTest/kotlin/com/monta/changelog/notify/CoAuthorExtractorTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/notify/CoAuthorExtractorTest.kt
@@ -1,0 +1,72 @@
+package com.monta.changelog.notify
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class CoAuthorExtractorTest :
+    StringSpec({
+
+        "extract should return empty list when there are no trailers" {
+            CoAuthorExtractor.extract(listOf("fix: do the thing\n\nno trailers here")) shouldBe emptyList()
+        }
+
+        "extract should parse a co-authored-by trailer with a github noreply email" {
+            val message = """
+                fix: do the thing
+
+                Co-authored-by: Jane Doe <12345+janedoe@users.noreply.github.com>
+            """.trimIndent()
+
+            CoAuthorExtractor.extract(listOf(message)) shouldBe listOf(
+                CoAuthorExtractor.CoAuthor(name = "Jane Doe", email = "12345+janedoe@users.noreply.github.com", login = "janedoe")
+            )
+        }
+
+        "extract should parse a co-authored-by trailer with a regular email and no login" {
+            val message = "fix: do the thing\n\nCo-authored-by: Jane Doe <jane@example.com>"
+
+            CoAuthorExtractor.extract(listOf(message)) shouldBe listOf(
+                CoAuthorExtractor.CoAuthor(name = "Jane Doe", email = "jane@example.com", login = null)
+            )
+        }
+
+        "extract should be case-insensitive on the trailer keyword" {
+            val message = "fix: do the thing\n\nco-authored-by: Jane Doe <jane@example.com>"
+
+            CoAuthorExtractor.extract(listOf(message)) shouldBe listOf(
+                CoAuthorExtractor.CoAuthor(name = "Jane Doe", email = "jane@example.com", login = null)
+            )
+        }
+
+        "extract should handle multiple co-authors across multiple commit messages" {
+            val messages = listOf(
+                "fix: a\n\nCo-authored-by: Jane Doe <jane@example.com>",
+                "fix: b\n\nCo-authored-by: John Smith <54321+johnsmith@users.noreply.github.com>"
+            )
+
+            CoAuthorExtractor.extract(messages) shouldBe listOf(
+                CoAuthorExtractor.CoAuthor(name = "Jane Doe", email = "jane@example.com", login = null),
+                CoAuthorExtractor.CoAuthor(name = "John Smith", email = "54321+johnsmith@users.noreply.github.com", login = "johnsmith")
+            )
+        }
+
+        "extract should deduplicate identical trailers appearing in multiple commits" {
+            val messages = listOf(
+                "fix: a\n\nCo-authored-by: Jane Doe <jane@example.com>",
+                "fix: b\n\nCo-authored-by: Jane Doe <jane@example.com>"
+            )
+
+            CoAuthorExtractor.extract(messages) shouldBe listOf(
+                CoAuthorExtractor.CoAuthor(name = "Jane Doe", email = "jane@example.com", login = null)
+            )
+        }
+
+        "extract should not match a bot noreply email without a plus-prefixed id" {
+            val message = "fix: a\n\nCo-authored-by: dependabot[bot] <dependabot[bot]@users.noreply.github.com>"
+
+            val result = CoAuthorExtractor.extract(listOf(message))
+            result shouldBe listOf(
+                CoAuthorExtractor.CoAuthor(name = "dependabot[bot]", email = "dependabot[bot]@users.noreply.github.com", login = null)
+            )
+        }
+    })

--- a/src/commonTest/kotlin/com/monta/changelog/notify/MonitoringUrlTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/notify/MonitoringUrlTest.kt
@@ -1,0 +1,59 @@
+package com.monta.changelog.notify
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+class MonitoringUrlTest :
+    StringSpec({
+
+        "parse should return null for blank input" {
+            MonitoringUrl.parse("").shouldBeNull()
+            MonitoringUrl.parse("   ").shouldBeNull()
+        }
+
+        "parse should use the url as the label for a bare url" {
+            MonitoringUrl.parse("https://grafana.example.com/d/abc") shouldBe MonitoringUrl(
+                label = "https://grafana.example.com/d/abc",
+                url = "https://grafana.example.com/d/abc"
+            )
+        }
+
+        "parse should split label and url on the pipe character" {
+            MonitoringUrl.parse("Grafana|https://grafana.example.com/d/abc") shouldBe MonitoringUrl(
+                label = "Grafana",
+                url = "https://grafana.example.com/d/abc"
+            )
+        }
+
+        "parse should trim whitespace around label and url" {
+            MonitoringUrl.parse("  Grafana  |  https://grafana.example.com/d/abc  ") shouldBe MonitoringUrl(
+                label = "Grafana",
+                url = "https://grafana.example.com/d/abc"
+            )
+        }
+
+        "parse should treat a url containing a trailing pipe with a blank side as a bare url" {
+            MonitoringUrl.parse("https://grafana.example.com/d/abc|") shouldBe MonitoringUrl(
+                label = "https://grafana.example.com/d/abc|",
+                url = "https://grafana.example.com/d/abc|"
+            )
+        }
+
+        "parseAll should return an empty list for null input" {
+            MonitoringUrl.parseAll(null) shouldBe emptyList()
+        }
+
+        "parseAll should parse every non-blank entry" {
+            MonitoringUrl.parseAll(
+                listOf(
+                    "Grafana|https://grafana.example.com",
+                    "",
+                    "https://sentry.example.com"
+                )
+            ) shouldBe listOf(
+                MonitoringUrl(label = "Grafana", url = "https://grafana.example.com"),
+                MonitoringUrl(label = "https://sentry.example.com", url = "https://sentry.example.com")
+            )
+        }
+    })

--- a/src/commonTest/kotlin/com/monta/changelog/notify/ReleaseNotificationServiceTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/notify/ReleaseNotificationServiceTest.kt
@@ -1,0 +1,343 @@
+package com.monta.changelog.notify
+
+import com.monta.changelog.github.GitHubService
+import com.monta.changelog.model.ChangeLog
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+private fun testChangeLog(
+    tagName: String = "v1.0.0",
+    githubReleaseUrl: String? = null,
+    repositoryUrl: String? = "https://github.com/monta-app/changelog-cli",
+    previousTagName: String? = null,
+) = ChangeLog(
+    serviceName = "changelog-cli",
+    jiraAppName = null,
+    tagName = tagName,
+    previousTagName = previousTagName,
+    repoOwner = "monta-app",
+    repoName = "changelog-cli",
+    repositoryUrl = repositoryUrl,
+    groupedCommitMap = emptyMap()
+).also { it.githubReleaseUrl = githubReleaseUrl }
+
+class ReleaseNotificationServiceTest :
+    StringSpec({
+
+        "addContributor should mark a login-based contributor as author" {
+            val contributors = mutableMapOf<String, Contributor>()
+
+            addContributor(contributors, login = "alice", prNumber = 1) { it.isAuthor = true }
+
+            contributors.values.single().let { contributor ->
+                contributor.login shouldBe "alice"
+                contributor.isAuthor shouldBe true
+                contributor.isApprover shouldBe false
+                contributor.prNumbers shouldBe setOf(1)
+            }
+        }
+
+        "addContributor should merge author and approver roles for the same login" {
+            val contributors = mutableMapOf<String, Contributor>()
+
+            addContributor(contributors, login = "alice", prNumber = 1) { it.isAuthor = true }
+            addContributor(contributors, login = "alice", prNumber = 2) { it.isApprover = true }
+
+            contributors.values.single().let { contributor ->
+                contributor.isAuthor shouldBe true
+                contributor.isApprover shouldBe true
+                contributor.prNumbers shouldBe setOf(1, 2)
+            }
+        }
+
+        "addContributor should skip bot logins" {
+            val contributors = mutableMapOf<String, Contributor>()
+
+            addContributor(contributors, login = "dependabot[bot]", prNumber = 1) { it.isAuthor = true }
+
+            contributors.shouldBeEmptyMap()
+        }
+
+        "addContributor should skip bot display names when there is no login" {
+            val contributors = mutableMapOf<String, Contributor>()
+
+            addContributor(
+                contributors,
+                email = "1+dependabot[bot]@users.noreply.github.com",
+                displayName = "dependabot[bot]",
+                prNumber = 1
+            ) { it.isCoAuthor = true }
+
+            contributors.shouldBeEmptyMap()
+        }
+
+        "addContributor should key a co-author without a login by email" {
+            val contributors = mutableMapOf<String, Contributor>()
+
+            addContributor(contributors, email = "jane@example.com", displayName = "Jane Doe", prNumber = 1) { it.isCoAuthor = true }
+
+            contributors.values.single().let { contributor ->
+                contributor.login.shouldBeNull()
+                contributor.email shouldBe "jane@example.com"
+                contributor.displayName shouldBe "Jane Doe"
+                contributor.isCoAuthor shouldBe true
+            }
+        }
+
+        "addContributor should merge a co-author with a known login into an existing author entry" {
+            val contributors = mutableMapOf<String, Contributor>()
+
+            addContributor(contributors, login = "alice", prNumber = 1) { it.isApprover = true }
+            addContributor(contributors, login = "alice", displayName = "Alice", prNumber = 1) { it.isCoAuthor = true }
+
+            contributors.values.single().let { contributor ->
+                contributor.isApprover shouldBe true
+                contributor.isCoAuthor shouldBe true
+                contributor.isAuthor shouldBe false
+            }
+        }
+
+        "sortContributors should put approver-only contributors last" {
+            val alice = Contributor(login = "alice", email = null, displayName = "alice").apply { isApprover = true }
+            val bob = Contributor(login = "bob", email = null, displayName = "bob").apply { isAuthor = true }
+
+            sortContributors(listOf(alice, bob)).map { it.login } shouldContainExactly listOf("bob", "alice")
+        }
+
+        "sortContributors should keep co-authors ahead of approver-only contributors" {
+            val approver = Contributor(login = "approver-only", email = null, displayName = "approver-only").apply { isApprover = true }
+            val coAuthor = Contributor(login = "co-author-only", email = null, displayName = "co-author-only").apply { isCoAuthor = true }
+
+            sortContributors(listOf(approver, coAuthor)).map { it.login } shouldContainExactly listOf("co-author-only", "approver-only")
+        }
+
+        "sortContributors should sort alphabetically (case-insensitive) within the same tier" {
+            val bob = Contributor(login = "Bob", email = null, displayName = "Bob").apply { isAuthor = true }
+            val alice = Contributor(login = "alice", email = null, displayName = "alice").apply { isAuthor = true }
+
+            sortContributors(listOf(bob, alice)).map { it.login } shouldContainExactly listOf("alice", "Bob")
+        }
+
+        "buildRoleSuffix should be empty for an author" {
+            val contributor = Contributor(login = "alice", email = null, displayName = "alice").apply { isAuthor = true }
+            buildRoleSuffix(contributor) shouldBe ""
+        }
+
+        "buildRoleSuffix should be empty for an author who also approved or co-authored" {
+            val contributor = Contributor(login = "alice", email = null, displayName = "alice").apply {
+                isAuthor = true
+                isApprover = true
+                isCoAuthor = true
+            }
+            buildRoleSuffix(contributor) shouldBe ""
+        }
+
+        "buildRoleSuffix should say approver for an approver-only contributor" {
+            val contributor = Contributor(login = "alice", email = null, displayName = "alice").apply { isApprover = true }
+            buildRoleSuffix(contributor) shouldBe " (approver)"
+        }
+
+        "buildRoleSuffix should say co-author for a co-author-only contributor" {
+            val contributor = Contributor(login = "alice", email = null, displayName = "alice").apply { isCoAuthor = true }
+            buildRoleSuffix(contributor) shouldBe " (co-author)"
+        }
+
+        "buildRoleSuffix should combine co-author and approver roles" {
+            val contributor = Contributor(login = "alice", email = null, displayName = "alice").apply {
+                isCoAuthor = true
+                isApprover = true
+            }
+            buildRoleSuffix(contributor) shouldBe " (co-author, approver)"
+        }
+
+        "buildPrLinks should link every pr number using the known html url" {
+            val links = buildPrLinks(
+                repoOwner = "monta-app",
+                repoName = "changelog-cli",
+                prNumbers = setOf(2, 1),
+                prUrls = mapOf(1 to "https://github.com/monta-app/changelog-cli/pull/1", 2 to "https://github.com/monta-app/changelog-cli/pull/2")
+            )
+
+            links shouldBe "<https://github.com/monta-app/changelog-cli/pull/1|#1> <https://github.com/monta-app/changelog-cli/pull/2|#2>"
+        }
+
+        "buildPrLinks should fall back to a constructed url when the html url is unknown" {
+            val links = buildPrLinks(
+                repoOwner = "monta-app",
+                repoName = "changelog-cli",
+                prNumbers = setOf(5),
+                prUrls = emptyMap()
+            )
+
+            links shouldBe "<https://github.com/monta-app/changelog-cli/pull/5|#5>"
+        }
+
+        "formatMention should prefer a real slack mention when a slack user id is known" {
+            formatMention(slackUserId = "U123", login = "alice", displayName = "alice") shouldBe "<@U123>"
+        }
+
+        "formatMention should fall back to a github profile link when there is a login but no slack match" {
+            formatMention(slackUserId = null, login = "alice", displayName = "alice") shouldBe "<https://github.com/alice|@alice>"
+        }
+
+        "formatMention should fall back to the plain display name when there is no login either" {
+            formatMention(slackUserId = null, login = null, displayName = "Jane Doe") shouldBe "Jane Doe"
+        }
+
+        "buildMentionLine should combine mention, role suffix and pr links" {
+            val contributor = Contributor(login = "alice", email = null, displayName = "alice").apply {
+                isApprover = true
+                prNumbers.add(1)
+            }
+
+            val line = buildMentionLine(
+                repoOwner = "monta-app",
+                repoName = "changelog-cli",
+                contributor = contributor,
+                prUrls = emptyMap(),
+                mention = "<@U123>"
+            )
+
+            line shouldBe "• <@U123> (approver) <https://github.com/monta-app/changelog-cli/pull/1|#1>"
+        }
+
+        "shouldSkipNotification should be true when there are no prs and no monitoring urls" {
+            shouldSkipNotification(emptyList(), emptyList()) shouldBe true
+        }
+
+        "shouldSkipNotification should be false when there are prs even without monitoring urls" {
+            shouldSkipNotification(listOf(1), emptyList()) shouldBe false
+        }
+
+        "shouldSkipNotification should be false when there are monitoring urls even without prs" {
+            shouldSkipNotification(emptyList(), listOf(MonitoringUrl(label = "Grafana", url = "https://grafana.example.com"))) shouldBe false
+        }
+
+        "buildContributors should collect the author and approvers of a single pr" {
+            val (contributors, prUrls) = buildContributors(
+                prNumbers = listOf(42),
+                getPullRequestDetails = {
+                    GitHubService.PullRequestDetails(
+                        number = 42,
+                        author = "alice",
+                        htmlUrl = "https://github.com/monta-app/changelog-cli/pull/42",
+                        approvers = listOf("bob")
+                    )
+                },
+                getPullRequestCommitMessages = { emptyList() }
+            )
+
+            prUrls shouldBe mapOf(42 to "https://github.com/monta-app/changelog-cli/pull/42")
+            contributors.values.map { Triple(it.login, it.isAuthor, it.isApprover) } shouldContainExactly listOf(
+                Triple("alice", true, false),
+                Triple("bob", false, true)
+            )
+        }
+
+        "buildContributors should extract co-authors from pr commit messages" {
+            val (contributors, _) = buildContributors(
+                prNumbers = listOf(42),
+                getPullRequestDetails = {
+                    GitHubService.PullRequestDetails(number = 42, author = "alice", htmlUrl = null, approvers = emptyList())
+                },
+                getPullRequestCommitMessages = {
+                    listOf("fix: thing\n\nCo-authored-by: Jane Doe <jane@example.com>")
+                }
+            )
+
+            contributors.values.map { Triple(it.displayName, it.isAuthor, it.isCoAuthor) } shouldContainExactly listOf(
+                Triple("alice", true, false),
+                Triple("Jane Doe", false, true)
+            )
+        }
+
+        "buildContributors should merge a co-author back into an author entry via a github noreply login" {
+            val (contributors, _) = buildContributors(
+                prNumbers = listOf(1, 2),
+                getPullRequestDetails = { prNumber ->
+                    if (prNumber == 1) {
+                        GitHubService.PullRequestDetails(number = 1, author = "alice", htmlUrl = null, approvers = emptyList())
+                    } else {
+                        GitHubService.PullRequestDetails(number = 2, author = "bob", htmlUrl = null, approvers = emptyList())
+                    }
+                },
+                getPullRequestCommitMessages = { prNumber ->
+                    if (prNumber == 2) {
+                        listOf("fix: thing\n\nCo-authored-by: Alice <1+alice@users.noreply.github.com>")
+                    } else {
+                        emptyList()
+                    }
+                }
+            )
+
+            contributors.size shouldBe 2
+            contributors["alice"]!!.let { alice ->
+                alice.isAuthor shouldBe true
+                alice.isCoAuthor shouldBe true
+                alice.prNumbers shouldBe setOf(1, 2)
+            }
+        }
+
+        "buildContributors should exclude bot authors, approvers and co-authors" {
+            val (contributors, _) = buildContributors(
+                prNumbers = listOf(1),
+                getPullRequestDetails = {
+                    GitHubService.PullRequestDetails(
+                        number = 1,
+                        author = "renovate[bot]",
+                        htmlUrl = null,
+                        approvers = listOf("dependabot[bot]")
+                    )
+                },
+                getPullRequestCommitMessages = {
+                    listOf("fix: thing\n\nCo-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>")
+                }
+            )
+
+            contributors.shouldBeEmptyMap()
+        }
+
+        "buildReleaseNotificationBlocks should prefer the github release url over a constructed one" {
+            val changeLog = testChangeLog(tagName = "v1.0.0", githubReleaseUrl = "https://github.com/monta-app/changelog-cli/releases/tag/v1.0.0")
+
+            val blocks = buildReleaseNotificationBlocks(changeLog, emptyList(), emptyList())
+
+            blocks shouldHaveSize 1
+            blocks[0].text?.text shouldContain "https://github.com/monta-app/changelog-cli/releases/tag/v1.0.0"
+        }
+
+        "buildReleaseNotificationBlocks should construct a release url when there is no github release" {
+            val changeLog = testChangeLog(tagName = "v1.0.0", githubReleaseUrl = null, repositoryUrl = "https://github.com/monta-app/changelog-cli")
+
+            val blocks = buildReleaseNotificationBlocks(changeLog, emptyList(), emptyList())
+
+            blocks[0].text?.text shouldContain "https://github.com/monta-app/changelog-cli/releases/tag/v1.0.0"
+        }
+
+        "buildReleaseNotificationBlocks should omit the dashboards section when there are no monitoring urls" {
+            val blocks = buildReleaseNotificationBlocks(testChangeLog(), emptyList(), listOf("• <@U1> #1"))
+
+            blocks shouldHaveSize 2
+            blocks.none { it.text?.text?.contains("Dashboards") == true } shouldBe true
+        }
+
+        "buildReleaseNotificationBlocks should include dashboards and contributors when both are present" {
+            val blocks = buildReleaseNotificationBlocks(
+                testChangeLog(),
+                listOf(MonitoringUrl(label = "Grafana", url = "https://grafana.example.com")),
+                listOf("• <@U1> #1")
+            )
+
+            blocks shouldHaveSize 3
+            blocks[1].text?.text shouldContain "Grafana"
+            blocks[2].text?.text shouldContain "<@U1> #1"
+        }
+    })
+
+private fun Map<String, Contributor>.shouldBeEmptyMap() {
+    this shouldBe emptyMap()
+}


### PR DESCRIPTION
Adds a standalone release-notification feature, independent of --output, that posts to a configured Slack channel with the release link, a configurable list of dashboards to monitor, and a tagged/ linked list of everyone who authored, co-authored, or approved the PRs in the release.

New properties:
- --monitoring-urls / CHANGELOG_MONITORING_URLS (optional): comma- separated list of dashboard/monitoring URLs to include. Each entry is either a bare URL or "Label|https://url" to give it a display label.
- --release-notify-channel / CHANGELOG_RELEASE_NOTIFY_CHANNEL (optional): Slack channel ID or name to post the notification to. Setting this is what turns the feature on.
- --release-notify-slack-token / CHANGELOG_SLACK_TOKEN (optional): Slack bot token used to post the notification and to resolve contributors' Slack accounts via users.lookupByEmail. Shares the CHANGELOG_SLACK_TOKEN env var with the existing --output slack printer, so no separate token is needed if that's already configured; the token needs the users:read.email scope in addition to chat:write for full contributor tagging.

@danielmfj the stuff we discussed - making it simpler for service maintainers to configure list of dashboards that contributers need to consult when releaseing