### PR TITLE
feat(notify): DM release authors to monitor their change [CPONETOPS-1176]

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ CHANGELOG_IMAGE_TAG # Current Docker image tag being deployed (e.g., commit SHA)
 CHANGELOG_PREVIOUS_IMAGE_TAG # Previous Docker image tag for rollback reference (shown in Slack metadata) [optional]
 CHANGELOG_MONITORING_URLS # Comma-separated list of dashboard/monitoring URLs for the release notification. Each entry is a bare URL or 'Label|https://url' [optional]
 CHANGELOG_RELEASE_NOTIFY_CHANNEL # Slack channel ID or name to post a release notification to, tagging PR authors/approvers and linking the monitoring URLs [optional, requires CHANGELOG_SLACK_TOKEN]
+CHANGELOG_DM_AUTHORS # Send each author of the release a DM telling them their change is deployed and pointing them at the monitoring URLs [optional, requires CHANGELOG_SLACK_TOKEN and CHANGELOG_MONITORING_URLS]
+CHANGELOG_IDENTITY_API_URL # Base URL of the identity resolver used to map GitHub logins to Slack accounts [optional, strongly recommended with CHANGELOG_DM_AUTHORS]
 ```
 
 At least one of `CHANGELOG_SLACK_CHANNEL_NAME` and `CHANGELOG_SLACK_CHANNELS` is required if output is set to `slack`
@@ -68,6 +70,58 @@ Contributors are tagged with a real Slack mention (`@user`) when their public Gi
 account; otherwise they're linked to their GitHub profile instead. Anyone who only approved a pull request
 (and didn't author one in this release) is suffixed with `(approver)`. Requires `CHANGELOG_GITHUB_TOKEN` to
 resolve PR authors/approvers.
+
+### Author DMs
+
+`CHANGELOG_DM_AUTHORS` adds a **second, separate** message: a direct message to each author of the release,
+telling them their change is deployed and pointing them at the dashboards to watch. The channel notification
+above is unchanged and independent - you can run either, both, or neither.
+
+```shell
+CHANGELOG_DM_AUTHORS=true
+CHANGELOG_SLACK_TOKEN=xoxb-...
+CHANGELOG_MONITORING_URLS="Server Error Dashboard|https://montaapp.grafana.net/d/ja52q4d/server-error-dashboard?from=now-30m&to=now&timezone=browser&var-container=$__all&var-filter=&var-Filters="
+CHANGELOG_IDENTITY_API_URL=https://project-tracker.vpn.internal.monta.app
+```
+
+The DM looks roughly like:
+
+```
+🚀 Your changes are live - Monta PHP Monolith release 2026-08-19-11-52 is now deployed to Production.
+Please keep an eye out for errors over the next 30 minutes:
+• Server Error Dashboard
+Your pull requests in this release: #25545
+```
+
+A channel announcement is easy for everyone to scroll past; a DM lands as a personal to-do, which is the point.
+Only authors and co-authors are messaged - reviewers aren't put on release watch, since the person who wrote the
+change is the one who can tell whether it's misbehaving.
+
+The headline only claims the change is **live** when the deployment has actually finished (both
+`CHANGELOG_DEPLOYMENT_START_TIME` and `CHANGELOG_DEPLOYMENT_END_TIME` are set). Otherwise it says the release is
+*being deployed*, matching the `⏳ Deployment pending` state the PR and Jira comments already use - a DM that
+tells you to go look at a dashboard before your code is running is worse than no DM.
+
+#### Reaching the author in Slack
+
+Mapping a GitHub author to a Slack account is the hard part of this feature, and doing it from GitHub data alone
+does not work well:
+
+| What we can read from GitHub | How often it reaches Slack |
+|------------------------------|----------------------------|
+| Public profile email         | Set on a small minority of org members - and may be the wrong domain (`cr@monta.app` on GitHub vs `cr@monta.com` in Slack) |
+| Commit author email          | Frequently a `users.noreply.github.com` or personal address Slack has never seen |
+
+So `CHANGELOG_IDENTITY_API_URL` should point at project-tracker's identity resolver, which is built for exactly
+this and knows each person's work email and Slack id. Resolution tries, in order: the resolver's Slack id, the
+resolver's work email, the `Co-authored-by:` trailer email, then the public GitHub profile email - each looked up
+in Slack via `users.lookupByEmail`.
+
+The resolver is **VPN-only**, so a GitHub-hosted runner can't reach it: join the runner to the tailnet with
+`tailscale/github-action` (the same `TAILSCALE_AUTHKEY` pattern several of our workflows already use) or run the
+job on a self-hosted runner. Without it the DM still works, but only for the authors whose GitHub-visible email
+happens to match Slack. Authors who can't be reached are named in a warning rather than silently skipped, so a
+missing DM is diagnosable from the job log.
 
 ### How to Release This Project
 

--- a/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/GenerateChangeLogCommand.kt
@@ -157,6 +157,19 @@ class GenerateChangeLogCommand : CliktCommand() {
         envvar = "CHANGELOG_SLACK_TOKEN"
     )
 
+    private val dmAuthors: Boolean by option(
+        "--dm-authors",
+        help = "Send each author of the release a direct message telling them their change is deployed and " +
+            "pointing them at the monitoring URLs (requires CHANGELOG_SLACK_TOKEN and CHANGELOG_MONITORING_URLS)",
+        envvar = "CHANGELOG_DM_AUTHORS"
+    ).flag(default = false)
+
+    private val identityApiUrl: String? by option(
+        help = "Base URL of the identity resolver used to map GitHub logins to Slack accounts, e.g. " +
+            "https://project-tracker.vpn.internal.monta.app (optional, improves author DM delivery)",
+        envvar = "CHANGELOG_IDENTITY_API_URL"
+    )
+
     private val output: PrintingConfig by option(
         help = "Name of the output used for printing the log (defaults to console)",
         envvar = "CHANGELOG_OUTPUT"
@@ -202,7 +215,9 @@ class GenerateChangeLogCommand : CliktCommand() {
                 commentOnJira = commentOnJira,
                 monitoringUrls = monitoringUrls?.filter { it.isNotBlank() },
                 releaseNotifyChannel = releaseNotifyChannel.valueOrNull(),
-                releaseNotifySlackToken = releaseNotifySlackToken.valueOrNull()
+                releaseNotifySlackToken = releaseNotifySlackToken.valueOrNull(),
+                dmAuthors = dmAuthors,
+                identityApiUrl = identityApiUrl.valueOrNull()
             )
 
             val commitShaOptions = commitShaOptions

--- a/src/commonMain/kotlin/com.monta.changelog/identity/IdentityService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/identity/IdentityService.kt
@@ -1,0 +1,98 @@
+package com.monta.changelog.identity
+
+import com.monta.changelog.util.DebugLogger
+import com.monta.changelog.util.client
+import com.monta.changelog.util.getBodySafe
+import io.ktor.client.request.get
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * A person as returned by project-tracker's identity resolver.
+ */
+@Serializable
+data class IdentityPerson(
+    @SerialName("displayName")
+    val displayName: String? = null,
+    @SerialName("email")
+    val email: String? = null,
+    @SerialName("isBot")
+    val isBot: Boolean = false,
+    @SerialName("githubLogin")
+    val githubLogin: String? = null,
+    @SerialName("slackUserId")
+    val slackUserId: String? = null,
+)
+
+@Serializable
+internal data class IdentityResolveResponse(
+    @SerialName("github")
+    val github: Map<String, IdentityPerson?> = emptyMap(),
+)
+
+/**
+ * Client for project-tracker's cross-system identity resolver, which maps a GitHub login to the
+ * person's work email and Slack id.
+ *
+ * We need it because a GitHub login on its own is not enough to reach someone in Slack: public
+ * GitHub profile emails are set on only a small minority of our org members, and the commit
+ * author email is just as often a `users.noreply.github.com` address or a personal one that Slack
+ * has never heard of. The resolver is the only place that knows, say, that `MithrandirDK` is
+ * `jake@monta.com`.
+ *
+ * The endpoint is VPN-only, so it is entirely optional: any failure - unset URL, a runner outside
+ * the tailnet, a bad response - is treated as "nobody resolved", and callers fall back to whatever
+ * they can derive from GitHub on their own.
+ */
+class IdentityService(
+    baseUrl: String,
+) {
+
+    private val resolveUrl = "${baseUrl.trimEnd('/')}/api/identity/resolve"
+
+    /**
+     * Resolves GitHub logins to people, keyed by lowercased login. Logins the resolver doesn't
+     * know are absent from the result rather than mapped to null.
+     */
+    suspend fun resolveByGithubLogins(logins: List<String>): Map<String, IdentityPerson> {
+        val distinctLogins = logins.filter { it.isNotBlank() }.distinct()
+        if (distinctLogins.isEmpty()) {
+            return emptyMap()
+        }
+
+        return distinctLogins
+            .chunked(MAX_HANDLES_PER_REQUEST)
+            .flatMap { chunk -> resolveChunk(chunk).entries }
+            .associate { entry -> entry.key to entry.value }
+    }
+
+    private suspend fun resolveChunk(chunk: List<String>): Map<String, IdentityPerson> {
+        val response = try {
+            client.get(resolveUrl) {
+                url {
+                    parameters.append("github", chunk.joinToString(","))
+                }
+            }
+        } catch (throwable: Throwable) {
+            // Expected whenever the job runs outside the tailnet - not worth failing the release over.
+            DebugLogger.warn("⚠️  Identity resolver unreachable at $resolveUrl: ${throwable.message}")
+            DebugLogger.warn("   → Falling back to GitHub-derived emails for Slack lookups")
+            return emptyMap()
+        }
+
+        val body = response.getBodySafe<IdentityResolveResponse>() ?: return emptyMap()
+
+        // The resolver echoes back the caller's spelling of each handle; normalise so lookups
+        // don't depend on how GitHub happened to capitalise the login.
+        return body.github.mapNotNull { (handle, person) ->
+            person?.let { handle.lowercase() to it }
+        }.toMap()
+    }
+
+    private companion object {
+        /**
+         * The resolver caps a request at 100 handles across all lookup types.
+         */
+        const val MAX_HANDLES_PER_REQUEST = 100
+    }
+}

--- a/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/log/ChangeLogService.kt
@@ -4,7 +4,9 @@ import com.monta.changelog.git.CommitInfo
 import com.monta.changelog.git.GitService
 import com.monta.changelog.git.sorter.TagSorter
 import com.monta.changelog.github.GitHubService
+import com.monta.changelog.identity.IdentityService
 import com.monta.changelog.model.ChangeLog
+import com.monta.changelog.notify.AuthorDmService
 import com.monta.changelog.notify.MonitoringUrl
 import com.monta.changelog.notify.ReleaseNotificationService
 import com.monta.changelog.printer.ChangeLogPrinter
@@ -40,6 +42,8 @@ class ChangeLogService(
     private val monitoringUrls: List<String>? = null,
     private val releaseNotifyChannel: String? = null,
     private val releaseNotifySlackToken: String? = null,
+    private val dmAuthors: Boolean = false,
+    private val identityApiUrl: String? = null,
 ) {
 
     private val gitService = GitService(tagSorter, tagPattern, pathExcludePattern)
@@ -58,6 +62,19 @@ class ChangeLogService(
             slackChannel = releaseNotifyChannel,
             monitoringUrls = MonitoringUrl.parseAll(monitoringUrls),
             gitHubService = gitHubService
+        )
+    } else {
+        null
+    }
+
+    // Independent of the channel notification: the DM needs a Slack token and dashboards, but no
+    // channel to post to.
+    private val authorDmService = if (dmAuthors && releaseNotifySlackToken != null) {
+        AuthorDmService(
+            slackToken = releaseNotifySlackToken,
+            monitoringUrls = MonitoringUrl.parseAll(monitoringUrls),
+            gitHubService = gitHubService,
+            identityService = identityApiUrl?.let { IdentityService(it) }
         )
     } else {
         null
@@ -102,6 +119,13 @@ class ChangeLogService(
         if (releaseNotifyChannel != null && releaseNotifySlackToken == null) {
             DebugLogger.warn("⚠️  Release notify channel is set but no Slack token was provided")
             DebugLogger.warn("   → Set CHANGELOG_SLACK_TOKEN to enable the release notification message")
+        }
+        if (dmAuthors && releaseNotifySlackToken == null) {
+            DebugLogger.warn("⚠️  Author DMs are enabled but no Slack token was provided")
+            DebugLogger.warn("   → Set CHANGELOG_SLACK_TOKEN to enable the author DM")
+        }
+        if (dmAuthors) {
+            DebugLogger.info("dmAuthors     enabled${if (identityApiUrl == null) " (no identity resolver configured)" else ""}")
         }
     }
 
@@ -260,6 +284,13 @@ class ChangeLogService(
 
         if (releaseNotificationService != null) {
             releaseNotificationService.notify(
+                changeLog = changeLog,
+                pullRequests = validatedPrs
+            )
+        }
+
+        if (authorDmService != null) {
+            authorDmService.notifyAuthors(
                 changeLog = changeLog,
                 pullRequests = validatedPrs
             )

--- a/src/commonMain/kotlin/com.monta.changelog/notify/AuthorDm.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/notify/AuthorDm.kt
@@ -1,0 +1,83 @@
+package com.monta.changelog.notify
+
+import com.monta.changelog.model.ChangeLog
+import com.monta.changelog.printer.slack.SlackBlock
+import com.monta.changelog.printer.slack.SlackText
+
+/**
+ * How long we ask an author to keep an eye on the dashboards after their change goes out.
+ */
+private const val MONITORING_WINDOW = "the next 30 minutes"
+
+/**
+ * True once the deployment has actually finished. Both ends of the timing have to be known,
+ * matching how the PR and Jira comments tell "Deployed" from "Deployment pending" - we don't want
+ * to tell someone their change is live while it's still rolling out.
+ */
+internal val ChangeLog.isDeploymentComplete: Boolean
+    get() = deploymentStartTime != null && deploymentEndTime != null
+
+/**
+ * Builds the DM's opening line. Says the release is deployed once it actually is, and otherwise
+ * says it's on the way, so the message is honest either way about what the author is looking at.
+ */
+internal fun buildAuthorDmHeadline(changeLog: ChangeLog): String {
+    val releaseUrl = changeLog.githubReleaseUrl
+        ?: changeLog.repositoryUrl?.let { "$it/releases/tag/${changeLog.tagName}" }
+    val release = if (releaseUrl != null) {
+        "<$releaseUrl|${changeLog.tagName}>"
+    } else {
+        changeLog.tagName
+    }
+    val stageText = changeLog.stage
+        ?.let { stage -> " to ${stage.replaceFirstChar { char -> char.uppercaseChar() }}" }
+        ?: ""
+
+    return if (changeLog.isDeploymentComplete) {
+        ":rocket: *Your changes are live* - ${changeLog.serviceName} release $release is now deployed$stageText."
+    } else {
+        ":hourglass_flowing_sand: *Your changes are on the way* - " +
+            "${changeLog.serviceName} release $release is being deployed$stageText now."
+    }
+}
+
+/**
+ * Builds the monitoring ask, listing the dashboards the author should watch.
+ */
+internal fun buildAuthorDmMonitoringAsk(monitoringUrls: List<MonitoringUrl>): String {
+    val dashboardLines = monitoringUrls.joinToString("\n") { "• <${it.url}|${it.label}>" }
+    return "Please keep an eye out for errors over $MONITORING_WINDOW:\n$dashboardLines"
+}
+
+/**
+ * Builds the DM sent to one author: what shipped, that it's deployed, and where to watch it.
+ * The author's own pull requests are listed so a busy release still tells them which change of
+ * theirs to keep an eye on.
+ */
+internal fun buildAuthorDmBlocks(
+    changeLog: ChangeLog,
+    monitoringUrls: List<MonitoringUrl>,
+    prLinks: String,
+): List<SlackBlock> = buildList {
+    add(dmSectionBlock(buildAuthorDmHeadline(changeLog)))
+    add(dmSectionBlock(buildAuthorDmMonitoringAsk(monitoringUrls)))
+
+    if (prLinks.isNotBlank()) {
+        add(dmSectionBlock("Your pull requests in this release: $prLinks"))
+    }
+}
+
+/**
+ * The plain-text fallback, which is what Slack shows in the sidebar and in a push notification -
+ * for a DM that is often the only part the author reads before deciding to open it.
+ */
+internal fun buildAuthorDmFallbackText(changeLog: ChangeLog): String = if (changeLog.isDeploymentComplete) {
+    "Your changes are live in ${changeLog.serviceName} release ${changeLog.tagName} - please monitor for errors"
+} else {
+    "Your changes are being deployed in ${changeLog.serviceName} release ${changeLog.tagName} - please monitor for errors"
+}
+
+private fun dmSectionBlock(text: String) = SlackBlock(
+    type = "section",
+    text = SlackText(type = "mrkdwn", text = text)
+)

--- a/src/commonMain/kotlin/com.monta.changelog/notify/AuthorDmService.kt
+++ b/src/commonMain/kotlin/com.monta.changelog/notify/AuthorDmService.kt
@@ -1,0 +1,204 @@
+package com.monta.changelog.notify
+
+import com.monta.changelog.github.GitHubService
+import com.monta.changelog.identity.IdentityPerson
+import com.monta.changelog.identity.IdentityService
+import com.monta.changelog.model.ChangeLog
+import com.monta.changelog.printer.slack.SlackBlock
+import com.monta.changelog.printer.slack.SlackMessageRequest
+import com.monta.changelog.printer.slack.SlackMessageResponse
+import com.monta.changelog.printer.slack.SlackUserResolver
+import com.monta.changelog.util.DebugLogger
+import com.monta.changelog.util.client
+import com.monta.changelog.util.getBodySafe
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.utils.io.charsets.Charsets
+import io.ktor.utils.io.charsets.name
+
+/**
+ * Finds the Slack account for one contributor, trying the identities most likely to be right
+ * first. In order:
+ *
+ *  1. The Slack id the identity resolver holds for them, which needs no guessing at all.
+ *  2. The work email the identity resolver holds for them - this is the address Slack knows, and
+ *     it is frequently *not* the one on their GitHub profile (`cr@monta.app` on GitHub versus
+ *     `cr@monta.com` in Slack, for instance).
+ *  3. Their `Co-authored-by:` trailer email, when they came in as a co-author.
+ *  4. Their public GitHub profile email, which most people don't set - tried last because it costs
+ *     an extra API call to read.
+ *
+ * Returns null when none of those reach a Slack account, which the caller reports rather than
+ * silently dropping - an author who is never told to monitor is the whole problem we're solving.
+ */
+internal suspend fun resolveSlackUserId(
+    contributor: Contributor,
+    identity: IdentityPerson?,
+    githubProfileEmail: suspend () -> String?,
+    lookupByEmail: suspend (String) -> String?,
+): String? {
+    identity?.slackUserId?.let { return it }
+
+    // Addresses we already hold, so we spend no GitHub call unless we have to.
+    listOfNotNull(identity?.email, contributor.email).distinct().forEach { email ->
+        lookupByEmail(email)?.let { return it }
+    }
+
+    val profileEmail = githubProfileEmail() ?: return null
+    return lookupByEmail(profileEmail)
+}
+
+/**
+ * Sends each author of a release a direct message telling them their change is deployed and
+ * pointing them at the dashboards to watch.
+ *
+ * This is deliberately separate from [ReleaseNotificationService]: that one announces the release
+ * to a channel, where a monitoring ask is easy for everyone to scroll past. A DM lands as a
+ * personal to-do, which is the point - it makes post-release monitoring the default rather than
+ * something you have to remember to go and do.
+ *
+ * Only the people who wrote code (authors and co-authors) are messaged. Reviewers are not put on
+ * release watch, since the person who wrote the change is the one who can tell whether it is
+ * misbehaving.
+ */
+class AuthorDmService(
+    private val slackToken: String,
+    private val monitoringUrls: List<MonitoringUrl>,
+    private val gitHubService: GitHubService,
+    private val identityService: IdentityService?,
+) {
+
+    suspend fun notifyAuthors(
+        changeLog: ChangeLog,
+        pullRequests: List<String>,
+    ) {
+        if (monitoringUrls.isEmpty()) {
+            DebugLogger.warn("⚠️  Author DMs are enabled but no monitoring URLs were given - nothing to ask authors to watch")
+            DebugLogger.warn("   → Set CHANGELOG_MONITORING_URLS to enable the author DM")
+            return
+        }
+
+        val prNumbers = pullRequests.mapNotNull { it.toIntOrNull() }
+        if (prNumbers.isEmpty()) {
+            DebugLogger.debug("Skipping author DMs - no pull requests in this release")
+            return
+        }
+
+        val (contributors, prUrls) = collectContributors(changeLog, prNumbers)
+
+        val authors = contributors.values.filter { it.isAuthor || it.isCoAuthor }
+        if (authors.isEmpty()) {
+            DebugLogger.debug("Skipping author DMs - no human authors found in this release")
+            return
+        }
+
+        // One batched call for every author, rather than one lookup per person.
+        val identities = identityService
+            ?.resolveByGithubLogins(authors.mapNotNull { it.login })
+            ?: emptyMap()
+
+        val unresolved = mutableListOf<String>()
+
+        authors.forEach { author ->
+            val slackUserId = resolveSlackUserId(
+                contributor = author,
+                identity = author.login?.let { identities[it.lowercase()] },
+                githubProfileEmail = { author.login?.let { gitHubService.getUser(it)?.email } },
+                lookupByEmail = { email -> SlackUserResolver.lookupUserIdByEmail(slackToken, email) }
+            )
+
+            if (slackUserId == null) {
+                unresolved.add(author.displayName)
+                return@forEach
+            }
+
+            sendDm(
+                slackUserId = slackUserId,
+                changeLog = changeLog,
+                prLinks = buildPrLinks(
+                    repoOwner = changeLog.repoOwner,
+                    repoName = changeLog.repoName,
+                    prNumbers = author.prNumbers,
+                    prUrls = prUrls
+                )
+            )
+        }
+
+        if (unresolved.isNotEmpty()) {
+            DebugLogger.warn("⚠️  Could not reach ${unresolved.size} author(s) in Slack: ${unresolved.joinToString(", ")}")
+            DebugLogger.warn("   → Set CHANGELOG_IDENTITY_API_URL so logins can be resolved without a public GitHub email")
+        }
+    }
+
+    private suspend fun collectContributors(
+        changeLog: ChangeLog,
+        prNumbers: List<Int>,
+    ) = buildContributors(
+        prNumbers = prNumbers,
+        getPullRequestDetails = { prNumber ->
+            gitHubService.getPullRequestDetails(
+                repoOwner = changeLog.repoOwner,
+                repoName = changeLog.repoName,
+                prNumber = prNumber
+            )
+        },
+        getPullRequestCommitMessages = { prNumber ->
+            gitHubService.getPullRequestCommitMessages(
+                repoOwner = changeLog.repoOwner,
+                repoName = changeLog.repoName,
+                prNumber = prNumber
+            )
+        }
+    )
+
+    private suspend fun sendDm(
+        slackUserId: String,
+        changeLog: ChangeLog,
+        prLinks: String,
+    ) {
+        // Posting to a user id opens (or reuses) the DM conversation with them.
+        val posted = postMessage(
+            channel = slackUserId,
+            blocks = buildAuthorDmBlocks(
+                changeLog = changeLog,
+                monitoringUrls = monitoringUrls,
+                prLinks = prLinks
+            ),
+            fallbackText = buildAuthorDmFallbackText(changeLog)
+        )
+
+        if (posted) {
+            DebugLogger.debug("Sent release monitoring DM to $slackUserId")
+        }
+    }
+
+    private suspend fun postMessage(
+        channel: String,
+        blocks: List<SlackBlock>,
+        fallbackText: String,
+    ): Boolean {
+        val response = client.post("https://slack.com/api/chat.postMessage") {
+            header("Authorization", "Bearer $slackToken")
+            contentType(ContentType.Application.Json.withParameter("charset", Charsets.UTF_8.name))
+            setBody(
+                SlackMessageRequest(
+                    channel = channel,
+                    threadTs = null,
+                    text = fallbackText,
+                    blocks = blocks
+                )
+            )
+        }
+
+        val result = response.getBodySafe<SlackMessageResponse>()
+        if (result?.ok != true) {
+            DebugLogger.error("Could not send release monitoring DM to '$channel'")
+            return false
+        }
+
+        return true
+    }
+}

--- a/src/commonTest/kotlin/com/monta/changelog/identity/IdentityServiceTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/identity/IdentityServiceTest.kt
@@ -1,0 +1,58 @@
+package com.monta.changelog.identity
+
+import com.monta.changelog.util.json
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+
+/**
+ * A real response from project-tracker's resolver, trimmed to the fields we read. Note that
+ * `slackUserId` is null for everyone today - the Slack identities aren't synced yet - which is
+ * exactly why the work email matters as a second step.
+ */
+private const val REAL_RESPONSE = """
+{
+  "github": {
+    "Casperhr": {
+      "personId": "f336fb11-ccd9-4a5f-984e-9ca78e37012e",
+      "displayName": "Casper Rasmussen",
+      "email": "cr@monta.com",
+      "isBot": false,
+      "isActive": true,
+      "githubLogin": "Casperhr",
+      "slackUserId": null,
+      "identities": [{ "platform": "github", "id": "casperhr", "username": "Casperhr" }]
+    },
+    "ghost": null
+  }
+}
+"""
+
+class IdentityServiceTest :
+    StringSpec({
+
+        "should deserialize a real resolver response, including unknown fields" {
+            val response = json.decodeFromString<IdentityResolveResponse>(REAL_RESPONSE)
+
+            response.github.size shouldBe 2
+
+            val casper = response.github["Casperhr"]
+            casper?.displayName shouldBe "Casper Rasmussen"
+            // The address Slack knows - note GitHub's public profile says cr@monta.app instead.
+            casper?.email shouldBe "cr@monta.com"
+            casper?.githubLogin shouldBe "Casperhr"
+            casper?.slackUserId.shouldBeNull()
+            casper?.isBot shouldBe false
+        }
+
+        "should represent an unknown handle as a null person" {
+            val response = json.decodeFromString<IdentityResolveResponse>(REAL_RESPONSE)
+
+            response.github.containsKey("ghost") shouldBe true
+            response.github["ghost"].shouldBeNull()
+        }
+
+        "should tolerate a response with no github map at all" {
+            json.decodeFromString<IdentityResolveResponse>("""{"slack":{"U1":null}}""").github shouldBe emptyMap()
+        }
+    })

--- a/src/commonTest/kotlin/com/monta/changelog/notify/AuthorDmTest.kt
+++ b/src/commonTest/kotlin/com/monta/changelog/notify/AuthorDmTest.kt
@@ -1,0 +1,222 @@
+package com.monta.changelog.notify
+
+import com.monta.changelog.identity.IdentityPerson
+import com.monta.changelog.model.ChangeLog
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+
+private const val DASHBOARD_URL =
+    "https://montaapp.grafana.net/d/ja52q4d/server-error-dashboard?from=now-30m&to=now&var-container=\$__all"
+
+private val serverErrorDashboard = MonitoringUrl(label = "Server Error Dashboard", url = DASHBOARD_URL)
+
+private fun dmChangeLog(
+    serviceName: String = "Monta PHP Monolith",
+    tagName: String = "2026-08-19-11-52",
+    githubReleaseUrl: String? = null,
+    repositoryUrl: String? = "https://github.com/monta-app/server",
+    stage: String? = "production",
+    deploymentStartTime: String? = "2026-08-19T11:52:00Z",
+    deploymentEndTime: String? = "2026-08-19T11:55:00Z",
+) = ChangeLog(
+    serviceName = serviceName,
+    jiraAppName = null,
+    tagName = tagName,
+    previousTagName = null,
+    repoOwner = "monta-app",
+    repoName = "server",
+    repositoryUrl = repositoryUrl,
+    groupedCommitMap = emptyMap(),
+    stage = stage,
+    deploymentStartTime = deploymentStartTime,
+    deploymentEndTime = deploymentEndTime
+).also { it.githubReleaseUrl = githubReleaseUrl }
+
+private fun contributor(
+    login: String? = "alice",
+    email: String? = null,
+) = Contributor(login = login, email = email, displayName = login ?: email ?: "someone")
+
+class AuthorDmTest :
+    StringSpec({
+
+        "isDeploymentComplete should require both ends of the deployment timing" {
+            dmChangeLog().isDeploymentComplete shouldBe true
+            dmChangeLog(deploymentEndTime = null).isDeploymentComplete shouldBe false
+            dmChangeLog(deploymentStartTime = null).isDeploymentComplete shouldBe false
+            dmChangeLog(deploymentStartTime = null, deploymentEndTime = null).isDeploymentComplete shouldBe false
+        }
+
+        "buildAuthorDmHeadline should say the change is live once the deployment has finished" {
+            val headline = buildAuthorDmHeadline(dmChangeLog())
+
+            headline shouldContain "*Your changes are live*"
+            headline shouldContain "Monta PHP Monolith release"
+            headline shouldContain "is now deployed to Production."
+        }
+
+        "buildAuthorDmHeadline should say the change is on the way while the deployment is pending" {
+            val headline = buildAuthorDmHeadline(dmChangeLog(deploymentStartTime = null, deploymentEndTime = null))
+
+            headline shouldContain "*Your changes are on the way*"
+            headline shouldContain "is being deployed to Production now."
+            headline shouldNotContain "are live"
+        }
+
+        "buildAuthorDmHeadline should link the github release when there is one" {
+            val headline = buildAuthorDmHeadline(
+                dmChangeLog(githubReleaseUrl = "https://github.com/monta-app/server/releases/tag/2026-08-19-11-52")
+            )
+
+            headline shouldContain "<https://github.com/monta-app/server/releases/tag/2026-08-19-11-52|2026-08-19-11-52>"
+        }
+
+        "buildAuthorDmHeadline should construct a release url from the repository when there is no github release" {
+            buildAuthorDmHeadline(dmChangeLog()) shouldContain
+                "<https://github.com/monta-app/server/releases/tag/2026-08-19-11-52|2026-08-19-11-52>"
+        }
+
+        "buildAuthorDmHeadline should fall back to a plain tag name when there is no url at all" {
+            val headline = buildAuthorDmHeadline(dmChangeLog(repositoryUrl = null))
+
+            headline shouldContain "release 2026-08-19-11-52 is now deployed"
+            headline shouldNotContain "<http"
+        }
+
+        "buildAuthorDmHeadline should omit the stage when it is unknown" {
+            buildAuthorDmHeadline(dmChangeLog(stage = null)) shouldContain "is now deployed."
+        }
+
+        "buildAuthorDmMonitoringAsk should list every dashboard" {
+            val ask = buildAuthorDmMonitoringAsk(
+                listOf(serverErrorDashboard, MonitoringUrl(label = "Sentry", url = "https://sentry.example.com"))
+            )
+
+            ask shouldContain "keep an eye out for errors over the next 30 minutes:"
+            ask shouldContain "• <$DASHBOARD_URL|Server Error Dashboard>"
+            ask shouldContain "• <https://sentry.example.com|Sentry>"
+        }
+
+        "buildAuthorDmBlocks should include the headline, the ask and the author's own prs" {
+            val blocks = buildAuthorDmBlocks(
+                changeLog = dmChangeLog(),
+                monitoringUrls = listOf(serverErrorDashboard),
+                prLinks = "<https://github.com/monta-app/server/pull/25545|#25545>"
+            )
+
+            blocks shouldHaveSize 3
+            blocks[0].text?.text shouldContain "*Your changes are live*"
+            blocks[1].text?.text shouldContain "Server Error Dashboard"
+            blocks[2].text?.text shouldBe
+                "Your pull requests in this release: <https://github.com/monta-app/server/pull/25545|#25545>"
+        }
+
+        "buildAuthorDmBlocks should omit the pull request section when there are no links" {
+            val blocks = buildAuthorDmBlocks(dmChangeLog(), listOf(serverErrorDashboard), prLinks = "")
+
+            blocks shouldHaveSize 2
+            blocks.none { it.text?.text?.contains("Your pull requests") == true } shouldBe true
+        }
+
+        "buildAuthorDmFallbackText should describe the deployed and the pending case" {
+            buildAuthorDmFallbackText(dmChangeLog()) shouldBe
+                "Your changes are live in Monta PHP Monolith release 2026-08-19-11-52 - please monitor for errors"
+            buildAuthorDmFallbackText(dmChangeLog(deploymentEndTime = null)) shouldBe
+                "Your changes are being deployed in Monta PHP Monolith release 2026-08-19-11-52 - please monitor for errors"
+        }
+
+        // --- Slack identity resolution -------------------------------------------------------
+
+        "resolveSlackUserId should prefer the slack id the resolver already holds" {
+            val slackUserId = resolveSlackUserId(
+                contributor = contributor(),
+                identity = IdentityPerson(email = "alice@monta.com", slackUserId = "U_FROM_RESOLVER"),
+                githubProfileEmail = { error("should not read the github profile") },
+                lookupByEmail = { error("should not look up an email") }
+            )
+
+            slackUserId shouldBe "U_FROM_RESOLVER"
+        }
+
+        "resolveSlackUserId should use the resolver's work email when it holds no slack id" {
+            // Casper's real case: cr@monta.app on GitHub, cr@monta.com in Slack.
+            val slackUserId = resolveSlackUserId(
+                contributor = contributor(login = "Casperhr"),
+                identity = IdentityPerson(email = "cr@monta.com"),
+                githubProfileEmail = { "cr@monta.app" },
+                lookupByEmail = { email -> if (email == "cr@monta.com") "U_CASPER" else null }
+            )
+
+            slackUserId shouldBe "U_CASPER"
+        }
+
+        "resolveSlackUserId should fall back to the co-author trailer email" {
+            val slackUserId = resolveSlackUserId(
+                contributor = contributor(login = null, email = "jane@monta.com"),
+                identity = null,
+                githubProfileEmail = { null },
+                lookupByEmail = { email -> if (email == "jane@monta.com") "U_JANE" else null }
+            )
+
+            slackUserId shouldBe "U_JANE"
+        }
+
+        "resolveSlackUserId should fall back to the public github profile email last" {
+            var profileReads = 0
+            val slackUserId = resolveSlackUserId(
+                contributor = contributor(email = "stale@example.com"),
+                identity = null,
+                githubProfileEmail = {
+                    profileReads++
+                    "alice@monta.com"
+                },
+                lookupByEmail = { email -> if (email == "alice@monta.com") "U_ALICE" else null }
+            )
+
+            slackUserId shouldBe "U_ALICE"
+            profileReads shouldBe 1
+        }
+
+        "resolveSlackUserId should not read the github profile when an earlier email already matched" {
+            var profileReads = 0
+            resolveSlackUserId(
+                contributor = contributor(email = "alice@monta.com"),
+                identity = null,
+                githubProfileEmail = {
+                    profileReads++
+                    "alice@monta.com"
+                },
+                lookupByEmail = { "U_ALICE" }
+            ) shouldBe "U_ALICE"
+
+            profileReads shouldBe 0
+        }
+
+        "resolveSlackUserId should try each known address only once" {
+            val attempted = mutableListOf<String>()
+            resolveSlackUserId(
+                contributor = contributor(email = "alice@monta.com"),
+                identity = IdentityPerson(email = "alice@monta.com"),
+                githubProfileEmail = { null },
+                lookupByEmail = { email ->
+                    attempted.add(email)
+                    null
+                }
+            ).shouldBeNull()
+
+            attempted shouldBe listOf("alice@monta.com")
+        }
+
+        "resolveSlackUserId should be null when nothing reaches a slack account" {
+            resolveSlackUserId(
+                contributor = contributor(login = "ghost"),
+                identity = null,
+                githubProfileEmail = { null },
+                lookupByEmail = { null }
+            ).shouldBeNull()
+        }
+    })


### PR DESCRIPTION
From [this thread](https://monta-app01.slack.com/archives/C03CWQT78AD/p1787130836840529): make post-release monitoring as easy as possible, so a release is less likely to go out unmonitored as release frequency goes up.

**The existing notifications are untouched.** This only *adds* a second message: a DM to each author of the release. `ReleaseNotificationService` is unmodified — the wiring changes are additive (new opt-in options + one call site).

## The message

Opt in with `--dm-authors` / `CHANGELOG_DM_AUTHORS`. Needs `CHANGELOG_SLACK_TOKEN` and `CHANGELOG_MONITORING_URLS`, but no channel of its own.

```
🚀 Your changes are live - Monta PHP Monolith release 2026-08-19-11-52 is now deployed to Production.
Please keep an eye out for errors over the next 30 minutes:
• Server Error Dashboard
Your pull requests in this release: #25545
```

A channel announcement is easy for everyone to scroll past; a DM lands as a personal to-do. Only authors and co-authors are messaged — reviewers aren't put on release watch, since the person who wrote the change is the one who can tell whether it's misbehaving.

Dashboard per [Jan's point in the thread](https://monta-app01.slack.com/archives/C03CWQT78AD/p1787139176392749): the [Server Error Dashboard](https://montaapp.grafana.net/d/ja52q4d/server-error-dashboard?from=now-30m&to=now&timezone=browser&var-container=$__all&var-filter=&var-Filters=), not the older state-of-the-union one. It stays configuration (`monitoring-urls`), documented as the README example.

**Honesty about "deployed".** The DM only claims the change is *live* when both deployment timings are known; otherwise it says the release is *being deployed*. This matters concretely — see the monolith note below.

## Mapping a GitHub author to a Slack user

This is the hard part, and doing it from GitHub data alone does not work. Measured over `monta-app/server`:

| Signal | Reality |
|---|---|
| **Public GitHub profile email** | Set on **4 of 17** sampled org members. project-tracker's own comment puts it at "fewer than 10%". |
| **Wrong domain when it *is* set** | `Casperhr` → `cr@monta.app` on GitHub, but `cr@monta.com` in Slack. The lookup fails. |
| **Commit author email** (last 300 commits) | 43% `users.noreply.github.com`, 24% `@monta.com`, 18% `@monta.app`, 13% personal (gmail etc.) |
| **Per-author** | ~46% resolvable by email alone. `MithrandirDK` has no public email at all (Slack `jake@monta.com` — not derivable from name or login). `jariwiklund` commits as `jari.wiklund@gmail.com`, so **the author of this request wouldn't get a DM**. |

The right answer already exists: **`monta-app/project-tracker`'s identity resolver** (`GET /api/identity/resolve?github=a,b`), which is purpose-built for this and whose docstring names changelog-cli as an intended caller. I verified it resolves all three authors that email lookup fails on:

```
$ curl '.../api/identity/resolve?github=Casperhr,MithrandirDK,jariwiklund'
Casperhr      → cr@monta.com     (not the .app on GitHub)
MithrandirDK  → jake@monta.com
jariwiklund   → jawi@monta.com
```

⚠️ **`slackUserId` is currently `null` for everyone** — the Slack identity sync isn't populated yet. So the working chain today is *login → work email → `users.lookupByEmail`*. The code prefers `slackUserId` when present, so it gets better for free once that sync lands.

Resolution order (`resolveSlackUserId`): resolver's Slack id → resolver's work email → `Co-authored-by:` trailer email → public GitHub profile email. Set via `--identity-api-url`; entirely optional and fail-soft. Authors who can't be reached are **named in a warning**, not silently skipped.

⚠️ **The resolver is VPN-only.** The changelog job runs on `ubuntu-latest`, which can't reach it. Fix is the established org pattern — `tailscale/github-action` + `TAILSCALE_AUTHKEY` (as `service-feature/check-owner-teams.yml` does) or a self-hosted runner. Without it the DM still works, for the ~46% whose GitHub-visible email matches Slack.

## Wiring needed (not in this PR)

1. **`changelog-cli-action`** — expose `dm-authors` / `identity-api-url`, bump the pinned CLI version.
2. **`monta-app/server`** — pass `dm-authors` + `monitoring-urls`, and give the job tailnet access.
3. ⚠️ **The monolith can't say "deployed" yet.** `create-change-log` runs after `push-manifest`, and the *"Wait for ArgoCD sync" step is commented out* (`deploy.yml` L398–407), so no deployment timings are passed — which is exactly why the current Slack message reads `⏳ Deployment pending`. Until that wait is restored, the monolith's DM will correctly say "is being deployed" rather than "is live". Re-enabling it is the real fix if you want "live".

## Testing

`./gradlew allTests ktlintCheck` pass; detekt (org config, 1.23.8) clean for the new files; native binary builds and shows both new options. 21 new tests — DM wording for deployed/pending/stage/no-URL cases, dashboard lists, and every branch of the Slack resolution chain (including Casper's real `.app`/`.com` mismatch and "don't spend a GitHub call if an earlier address matched"). `IdentityServiceTest` parses a **real** captured resolver response.

Not exercised live: the actual `chat.postMessage` DM send — that would message real people. Worth a manual run against a test channel/user before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
